### PR TITLE
Don't build raml-rb gem in pre-install script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ rvm:
   - 2.3.0
 env:
   - COVERAGE=true
-before_install:
-  - git clone https://github.com/danascheider/raml-rb
-  - gem build raml-rb/raml-rb.gemspec
-  - gem install raml-rb-0.0.5.gem
 branches:
   only:
     - dev


### PR DESCRIPTION
Since version 0.0.5 of raml-rb is now released, it no longer needs to be cloned and built in the travis environment prior to running `bundle install`.