### PR TITLE
Use step method from cucumber

### DIFF
--- a/features/step_definitions/file_steps.rb
+++ b/features/step_definitions/file_steps.rb
@@ -1,11 +1,7 @@
 Given(/^a file named "([^"]*)" like "([^"]*)"$/) do |file, example|
   text = read_example(example)
-  steps %Q{
-    Given a file named "#{file}" with:
-      """
-      #{text}
-      """
-  }
+
+  step %(a file named "#{file}" with:), text
 end
 
 Given(/^a spec_helper\.rb file that requires rack\/test but not JSON$/) do


### PR DESCRIPTION
Hi @danascheider,

I used the code in this PR and the features are passing. Can you verify that?

~~~
% bundle exec rake
/home/user/.rvm/rubies/ruby-2.3.0/bin/ruby -I/home/user/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.4.4/lib:/home/user/.rvm/gems/ruby-2.3.0/gems/rspec-support-3.4.1/lib /home/user/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.4.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/home/user/tmp/rambo/spec/spec_helper.rb:4:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.

Rambo::CLI
  run!
    creates a spec/contract directory
    creates a spec_helper file
    creates foobar_spec.rb
  validate!
    with no file given
      exits
    with the wrong file format
      exits

Rambo::DocumentGenerator
  #generate_spec_dir!
    generates the spec/contract directory
  #generate_spec_helper!
    generates the spec_helper file
  #generate_spec_file!
    generates foobar_spec.rb

Rambo::RamlModels::Api
  #resources
    has the right number of resources
  #title
    returns the API title from the RAML doc

Rambo::RamlModels::Method
  #to_s
    returns the method name

Rambo::RamlModels::Resource
  #to_s
    returns the URI partial
  #http_methods
    returns the correct methods

Rambo::RSpec::ExampleGroup
  #render
    interpolates the correct values

Rambo::RSpec::Examples
  #generate!
    calls render on each group
    returns an array of strings
  #compose
    returns a string

Rambo::RSpec::SpecFile
  file with examples
    #initialize
      assigns @raml
    #template
      is a string
    #render
      interpolates the correct values
  file with schema
    #initialize
      assigns @raml
    #template
      is a string
    #render
{"data":[{"id":1,"first_name":"a","last_name":"g"}]}
      interpolates the correct values

Rambo::RSpec::SpecHelperFile
  #render
    when there is no spec helper file
      returns the template
    when there is a spec helper file
      ensures json is required
      ensures rack/test is required
      when JSON is already required
        doesn't require JSON again
      when rack/test is already required
        doesn't require rack/test again

Finished in 3.1 seconds (files took 0.24137 seconds to load)
28 examples, 0 failures

Coverage report generated for Cucumber Features, RSpec to /home/user/tmp/rambo/coverage. 326 / 328 LOC (99.39%) covered.
[Coveralls] Outside the CI environment, not sending data.
/home/user/.rvm/rubies/ruby-2.3.0/bin/ruby -S bundle exec cucumber --format pretty
Feature: Create specs from RAML
  The example files can be found in features/support/examples

  Scenario: Generate specs from a simple RAML file                                  # features/create_files.feature:5
    Given a file named "foo.raml" like "empty_raml.raml"                            # features/step_definitions/file_steps.rb:1
    When I run `rambo foo.raml`                                                     # aruba-0.14.1/lib/aruba/cucumber/command.rb:13
    Then the directory "spec/contract" should exist                                 # aruba-0.14.1/lib/aruba/cucumber/file.rb:91
    And the file "spec/contract/foo_spec.rb" should exist                           # aruba-0.14.1/lib/aruba/cucumber/file.rb:91
    And the file "spec/spec_helper.rb" should exist                                 # aruba-0.14.1/lib/aruba/cucumber/file.rb:91
    And the file "spec/spec_helper.rb" should contain:                              # aruba-0.14.1/lib/aruba/cucumber/file.rb:143
      """
      require "rack/test"
      require "json"
      """
    And the file "spec/contract/foo_spec.rb" should be like "empty_spec.rb.example" # features/step_definitions/file_steps.rb:19
    And the exit status should be 0                                                 # aruba-0.14.1/lib/aruba/cucumber/command.rb:277

Feature: Error handling

  Scenario: No filename is given                   # features/error_modes.feature:3
    When I run `rambo`                             # aruba-0.14.1/lib/aruba/cucumber/command.rb:13
    Then it should fail with "USAGE: rambo [FILE]" # aruba-0.14.1/lib/aruba/cucumber/command.rb:285

  Scenario: File given is not a RAML file                                          # features/error_modes.feature:7
    Given a file "foobar.yml" with:                                                # aruba-0.14.1/lib/aruba/cucumber/file.rb:23
      """
      foo: bar
      """
    When I run `rambo foobar.yml`                                                  # aruba-0.14.1/lib/aruba/cucumber/command.rb:13
    Then it should fail with "Unsupported file format. Please choose a RAML file." # aruba-0.14.1/lib/aruba/cucumber/command.rb:285

Feature: Generate simple API specs

  Scenario: Route with example                                                                          # features/generate_simple_api_specs.feature:3
    Given a file named "foo.raml" like "basic_raml_with_example.raml"                                   # features/step_definitions/file_steps.rb:1
    When I run `rambo foo.raml`                                                                         # aruba-0.14.1/lib/aruba/cucumber/command.rb:13
    Then the file "spec/contract/foo_spec.rb" should be like "simple_spec_file_with_example.rb.example" # features/step_definitions/file_steps.rb:19

  Scenario: Route with schema                                                                          # features/generate_simple_api_specs.feature:8
    Given a file named "foo.raml" like "basic_raml_with_schema.raml"                                   # features/step_definitions/file_steps.rb:1
    When I run `rambo foo.raml`                                                                        # aruba-0.14.1/lib/aruba/cucumber/command.rb:13
    Then the file "spec/contract/foo_spec.rb" should be like "simple_spec_file_with_schema.rb.example" # features/step_definitions/file_steps.rb:19

Feature: Modify spec helper

  Background:                                                         # features/modify_spec_helper.feature:3
    Given a file named "foo.raml" like "basic_raml_with_example.raml" # features/step_definitions/file_steps.rb:1

  Scenario: JSON and rack/test are required                                          # features/modify_spec_helper.feature:6
    Given a spec_helper.rb file that requires both JSON and rack/test                # features/step_definitions/file_steps.rb:15
    When I run `rambo foo.raml`                                                      # aruba-0.14.1/lib/aruba/cucumber/command.rb:13
    Then the file "spec/spec_helper.rb" should be like "good_spec_helper.rb.example" # features/step_definitions/file_steps.rb:19

  Scenario: Only JSON is required                                    # features/modify_spec_helper.feature:11
    Given a spec_helper.rb file that requires JSON but not rack/test # features/step_definitions/file_steps.rb:11
    When I run `rambo foo.raml`                                      # aruba-0.14.1/lib/aruba/cucumber/command.rb:13
    Then the file "spec/spec_helper.rb" should require "rack/test"   # features/step_definitions/file_steps.rb:29

  Scenario: Only rack/test is required                               # features/modify_spec_helper.feature:16
    Given a spec_helper.rb file that requires rack/test but not JSON # features/step_definitions/file_steps.rb:7
    When I run `rambo foo.raml`                                      # aruba-0.14.1/lib/aruba/cucumber/command.rb:13
    Then the file "spec/spec_helper.rb" should require "json"        # features/step_definitions/file_steps.rb:29

8 scenarios (8 passed)
31 steps (31 passed)
0m9.437s
[Coveralls] Outside the CI environment, not sending data.
~~~

Here's my Gemfile.lock

~~~
% cat Gemfile.lock

PATH
  remote: .
  specs:
    rambo (0.0.1)
      colorize (~> 0.7)
      json_test_data (~> 0.3.0.beta)
      rack-test (~> 0.6)
      raml-rb (~> 0.0.5)
      rspec (~> 3.4)

GEM
  remote: https://rubygems.org/
  specs:
    aruba (0.14.1)
      childprocess (~> 0.5.6)
      contracts (~> 0.9)
      cucumber (>= 1.3.19)
      ffi (~> 1.9.10)
      rspec-expectations (>= 2.99)
      thor (~> 0.19)
    builder (3.2.2)
    childprocess (0.5.9)
      ffi (~> 1.0, >= 1.0.11)
    colorize (0.7.7)
    contracts (0.13.0)
    coveralls (0.8.13)
      json (~> 1.8)
      simplecov (~> 0.11.0)
      term-ansicolor (~> 1.3)
      thor (~> 0.19.1)
      tins (~> 1.6.0)
    cucumber (2.3.3)
      builder (>= 2.1.2)
      cucumber-core (~> 1.4.0)
      cucumber-wire (~> 0.0.1)
      diff-lcs (>= 1.1.3)
      gherkin (~> 3.2.0)
      multi_json (>= 1.7.5, < 2.0)
      multi_test (>= 0.1.2)
    cucumber-core (1.4.0)
      gherkin (~> 3.2.0)
    cucumber-wire (0.0.1)
    diff-lcs (1.2.5)
    docile (1.1.5)
    ffi (1.9.10)
    gherkin (3.2.0)
    json (1.8.3)
    json_test_data (0.3.0.beta)
      regxing (~> 0.1.0.beta)
    multi_json (1.11.2)
    multi_test (0.1.2)
    rack (1.6.4)
    rack-test (0.6.3)
      rack (>= 1.0)
    rake (10.5.0)
    raml-rb (0.0.5)
    regxing (0.1.0.beta)
    rspec (3.4.0)
      rspec-core (~> 3.4.0)
      rspec-expectations (~> 3.4.0)
      rspec-mocks (~> 3.4.0)
    rspec-core (3.4.4)
      rspec-support (~> 3.4.0)
    rspec-expectations (3.4.0)
      diff-lcs (>= 1.2.0, < 2.0)
      rspec-support (~> 3.4.0)
    rspec-mocks (3.4.1)
      diff-lcs (>= 1.2.0, < 2.0)
      rspec-support (~> 3.4.0)
    rspec-support (3.4.1)
    simplecov (0.11.2)
      docile (~> 1.1.0)
      json (~> 1.8)
      simplecov-html (~> 0.10.0)
    simplecov-html (0.10.0)
    term-ansicolor (1.3.2)
      tins (~> 1.0)
    thor (0.19.1)
    tins (1.6.0)

PLATFORMS
  ruby

DEPENDENCIES
  aruba (~> 0.13)
  coveralls (~> 0.7)
  cucumber (~> 2.1)
  json (~> 1.7)
  rake (~> 10.5)
  rambo!
  simplecov (~> 0.11)

BUNDLED WITH
   1.11.2
~~~

This is a follow up to cucumber/aruba#38.