### PR TITLE
Fix cucumber failures

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,13 +1,6 @@
-require 'simplecov'
 require 'coveralls'
 
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-
-if ENV['COVERAGE']
-  SimpleCov.start do
-    add_filter 'app/secrets'
-  end
-end
+Coveralls.wear! if ENV["COVERAGE"] == "true"
 
 require 'aruba/cucumber'
 require_relative './cucumber_helper'

--- a/features/support/examples/rspec/simple_spec_file_with_example.rb.example
+++ b/features/support/examples/rspec/simple_spec_file_with_example.rb.example
@@ -5,7 +5,7 @@ describe "e-BookMobile API" do
 
   describe "/authors" do
     let(:route) { "/authors" }
-
+    
     describe "GET" do
       let(:response_body) do
         {

--- a/features/support/examples/rspec/simple_spec_file_with_schema.rb.example
+++ b/features/support/examples/rspec/simple_spec_file_with_schema.rb.example
@@ -5,7 +5,7 @@ describe "e-BookMobile API" do
 
   describe "/authors" do
     let(:route) { "/authors" }
-
+    
     describe "GET" do
       let(:response_body) do
         {

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -16,7 +16,15 @@ module Rambo
       print_logo
       generator.generate_spec_dir!
       generator.generate_spec_helper!
-      generator.generate_spec_file!
+      stdout.puts("Generating contract tests...")
+      sleep 0.4
+
+      begin
+        generator.generate_spec_file!
+        stdout.puts("Done!".green)
+      rescue NoMethodError
+        stdout.puts("Error: Please check your RAML syntax and/or file an issue report\n".red)
+      end
     end
 
     def validate!
@@ -30,10 +38,7 @@ module Rambo
 
     def print_logo
       stdout.puts logo.colorize(color: String.colors.sample)
-      sleep 0.5
-      stdout.puts "Generating contract tests..."
-      sleep 0.5
-      stdout.puts "Done!\n".green
+      sleep 0.4
     end
 
     def exit_for_missing_file

--- a/rambo.gemspec
+++ b/rambo.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'cucumber', '~> 2.1'
   s.add_development_dependency 'json', '~> 1.7'
   s.add_development_dependency 'rake', '~> 10.5'
-  s.add_development_dependency 'simplecov', '~> 0.11'
   s.add_development_dependency 'coveralls', '~> 0.7'
   s.add_development_dependency 'aruba', '~> 0.13'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,6 @@
-require "simplecov"
 require "coveralls"
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
-SimpleCov.start if ENV["COVERAGE"]
+Coveralls.wear! if ENV["COVERAGE"] == "true"
 
 require "rspec"
 require "rspec/core"


### PR DESCRIPTION
This PR fixes one of the two Cucumber failures that began happening as a result of fixing Aruba. It also removes SimpleCov and uses plain old Coveralls instead.