### PR TITLE
Update raml-rb gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,8 @@ Gemfile.lock
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 
-foobar.raml
-foo.raml
+/foobar.raml
+/foo.raml
 raml.rb
 
 /spec/contract/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ script:
   - bundle exec rspec
 env:
   - COVERAGE=true
+script:
+  - bundle exec rspec
 branches:
   only:
-    - dev
-    - staging
     - master
 sudo: false
 notifications:

--- a/features/support/foobar.raml
+++ b/features/support/foobar.raml
@@ -1,0 +1,30 @@
+#%RAML 0.8
+---
+title: e-BookMobile API
+baseUri: http://api.e-bookmobile.com/{version}
+version: v1
+
+/authors:
+  get:
+    description: Retrieve a list of authors
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              {
+                "data": [
+                  {
+                    "id": 1,
+                    "first_name": "Hermann",
+                    "last_name": "Hesse"
+                  },
+                  {
+                    "id": 2,
+                    "first_name": "Charles",
+                    "last_name": "Dickens"
+                  }
+                ],
+                "success": true,
+                "status": 200
+              }

--- a/lib/document_generator.rb
+++ b/lib/document_generator.rb
@@ -1,5 +1,5 @@
 require "fileutils"
-require "raml"
+require "raml-rb"
 
 require File.expand_path("../rspec/spec_file.rb", __FILE__)
 require File.expand_path("../rspec/spec_helper_file.rb", __FILE__)
@@ -10,7 +10,7 @@ module Rambo
 
     def initialize(file)
       @file = file
-      @raml = Raml.parse_file(file)
+      @raml = Raml::Parser.parse_file(file)
     end
 
     def generate_spec_dir!

--- a/lib/raml_models/api.rb
+++ b/lib/raml_models/api.rb
@@ -8,7 +8,7 @@ module Rambo
       end
 
       def resources
-        @resources ||= schema.resources.map {|uri, resource| Rambo::RamlModels::Resource.new(resource) }
+        @resources ||= schema.resources.map {|resource| Rambo::RamlModels::Resource.new(resource) }
       end
 
       def title

--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -10,19 +10,17 @@ module Rambo
       end
 
       def content_type
-        body.name
+        body.content_type
       end
 
       def example
-        example = body.example rescue body.last.example
-        @example ||= example || generate_from_schema || {}.to_json
+        @example ||= body.example || generate_from_schema || {}.to_json
       end
 
       private
 
       def generate_from_schema
-        schema = body.children.first.value
-        JSON.pretty_generate(JsonTestData.generate!(schema, ruby: true))
+        JSON.pretty_generate(JsonTestData.generate!(body.schema, ruby: true))
       end
     end
   end

--- a/lib/raml_models/method.rb
+++ b/lib/raml_models/method.rb
@@ -8,7 +8,7 @@ module Rambo
       end
 
       def method
-        schema.name
+        schema.method
       end
 
       def request_body
@@ -20,7 +20,7 @@ module Rambo
       end
 
       def responses
-        @responses ||= schema.children.map {|resp| Rambo::RamlModels::Response.new(resp) }
+        @responses ||= schema.responses.map {|resp| Rambo::RamlModels::Response.new(resp) }
       end
 
       private

--- a/lib/raml_models/method.rb
+++ b/lib/raml_models/method.rb
@@ -12,7 +12,7 @@ module Rambo
       end
 
       def request_body
-        Rambo::RamlModels::Body.new(request_body_from_schema) if request_body_from_schema
+        Rambo::RamlModels::Body.new(request_body_from_schema) if has_request_body?
       end
 
       def description
@@ -25,8 +25,13 @@ module Rambo
 
       private
 
+      def has_request_body?
+        schema.bodies.first != nil
+      end
+
       def request_body_from_schema
-        schema.children.first.children.first
+        return unless schema.bodies.first
+        schema.bodies.first.example || JSON.pretty_generate(JsonTestData.generate!(schema.bodies.first.schema, ruby: true))
       end
     end
   end

--- a/lib/raml_models/resource.rb
+++ b/lib/raml_models/resource.rb
@@ -12,7 +12,7 @@ module Rambo
       end
 
       def http_methods
-        @http_methods ||= schema.methods.map {|name, method| Rambo::RamlModels::Method.new(method) }
+        @http_methods ||= schema.methods.map {|method| Rambo::RamlModels::Method.new(method) }
       end
 
       alias_method :to_s, :uri_partial

--- a/lib/raml_models/resource.rb
+++ b/lib/raml_models/resource.rb
@@ -4,11 +4,11 @@ module Rambo
       attr_reader :schema
 
       def initialize(raml_resource)
-        @schema = raml_resource.is_a?(Array) ? raml_resource.last : raml_resource
+        @schema = raml_resource
       end
 
       def uri_partial
-        schema.name
+        schema.uri_partial
       end
 
       def http_methods

--- a/lib/raml_models/response.rb
+++ b/lib/raml_models/response.rb
@@ -8,7 +8,7 @@ module Rambo
       end
 
       def status_code
-        schema.name
+        schema.code
       end
 
       def bodies

--- a/lib/raml_models/response.rb
+++ b/lib/raml_models/response.rb
@@ -12,7 +12,7 @@ module Rambo
       end
 
       def bodies
-        @bodies ||= schema.bodies.map {|content_type, body| Rambo::RamlModels::Body.new(body) }
+        @bodies ||= schema.bodies.map {|body| Rambo::RamlModels::Body.new(body) }
       end
     end
   end

--- a/rambo.gemspec
+++ b/rambo.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.1.0"
 
   s.add_dependency "rspec", "~> 3.4"
-  s.add_dependency "raml_ruby", "~> 0.1", ">= 0.1.2"
+  s.add_dependency "raml-rb", "~> 0.0.6"
   s.add_dependency "rack-test", "~> 0.6"
   s.add_dependency "colorize", "~> 0.7"
   s.add_dependency "json_test_data", "~> 0.8"

--- a/spec/lib/raml_models/api_spec.rb
+++ b/spec/lib/raml_models/api_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Api do
   let(:raml_file) { File.expand_path("../../../support/multiple_resources.raml", __FILE__) }
-  let(:raml)      { Raml.parse_file(raml_file) }
+  let(:raml)      { Raml::Parser.parse_file(raml_file) }
 
   subject { described_class.new(raml) }
 

--- a/spec/lib/raml_models/body_spec.rb
+++ b/spec/lib/raml_models/body_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Body do
   let(:raml) { Raml::Parser.parse_file(raml_file) }
-  let(:body) { raml.resources.values.first.children.first.children.first.children.first }
+  let(:body) { raml.resources.first.methods.first.responses.first.bodies.first }
 
   subject { described_class.new(body) }
 
@@ -8,7 +8,7 @@ RSpec.describe Rambo::RamlModels::Body do
     let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
 
     it "returns the content type" do
-      expect(subject.content_type).to eql body.name
+      expect(subject.content_type).to eql body.content_type
     end
   end
 

--- a/spec/lib/raml_models/body_spec.rb
+++ b/spec/lib/raml_models/body_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Rambo::RamlModels::Body do
-  let(:raml) { Raml.parse_file(raml_file) }
+  let(:raml) { Raml::Parser.parse_file(raml_file) }
   let(:body) { raml.resources.values.first.children.first.children.first.children.first }
 
   subject { described_class.new(body) }

--- a/spec/lib/raml_models/method_spec.rb
+++ b/spec/lib/raml_models/method_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Rambo::RamlModels::Method do
-  let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
+  let(:raml_file) { File.expand_path("../../../support/foo.raml", __FILE__) }
   let(:raml) { Raml::Parser.parse_file(raml_file) }
   let(:method) { raml.resources.first.methods.first }
 
@@ -14,6 +14,12 @@ RSpec.describe Rambo::RamlModels::Method do
   describe "#description" do
     it "returns the description" do
       expect(subject.description).to eql method.description
+    end
+  end
+
+  describe "#request_body" do
+    it "returns a request body" do
+      expect(subject.request_body).to be_a Rambo::RamlModels::Body
     end
   end
 

--- a/spec/lib/raml_models/method_spec.rb
+++ b/spec/lib/raml_models/method_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Rambo::RamlModels::Method do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
   let(:raml) { Raml::Parser.parse_file(raml_file) }
-  let(:method) { raml.resources.first.last.children.first }
+  let(:method) { raml.resources.first.methods.first }
 
   subject { described_class.new(method) }
 
   describe "#to_s" do
     it "returns the method name" do
-      expect(subject.method).to eql method.name
+      expect(subject.method).to eql method.method
     end
   end
 

--- a/spec/lib/raml_models/method_spec.rb
+++ b/spec/lib/raml_models/method_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe Rambo::RamlModels::Method do
     end
   end
 
-  describe "#request_body" do
-    it "returns a request body" do
-      expect(subject.request_body).to be_a Rambo::RamlModels::Body
-    end
-  end
-
   describe "#responses" do
     it "returns an array of Response objects" do
       all_are_responses = subject.responses.all? {|resp| resp.is_a?(Rambo::RamlModels::Response) }

--- a/spec/lib/raml_models/method_spec.rb
+++ b/spec/lib/raml_models/method_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Method do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml) { Raml.parse_file(raml_file) }
+  let(:raml) { Raml::Parser.parse_file(raml_file) }
   let(:method) { raml.resources.first.last.children.first }
 
   subject { described_class.new(method) }

--- a/spec/lib/raml_models/method_spec.rb
+++ b/spec/lib/raml_models/method_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe Rambo::RamlModels::Method do
     end
   end
 
+  describe "#request_body" do
+    it "returns a request body" do
+      expect(subject.request_body).to be_a Rambo::RamlModels::Body
+    end
+  end
+
   describe "#responses" do
     it "returns an array of Response objects" do
       all_are_responses = subject.responses.all? {|resp| resp.is_a?(Rambo::RamlModels::Response) }

--- a/spec/lib/raml_models/resource_spec.rb
+++ b/spec/lib/raml_models/resource_spec.rb
@@ -1,20 +1,19 @@
 RSpec.describe Rambo::RamlModels::Resource do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
   let(:raml) { Raml::Parser.parse_file(raml_file) }
-  let(:uri_partial) { raml.resources.first.first }
   let(:resource) { raml.resources.first }
 
   subject { described_class.new(resource) }
 
   describe "#to_s" do
     it "returns the URI partial" do
-      expect(subject.to_s).to eql uri_partial
+      expect(subject.to_s).to eql resource.uri_partial
     end
   end
 
   describe "#uri_partial" do
     it "returns the URI partial" do
-      expect(subject.uri_partial).to eql resource.first
+      expect(subject.uri_partial).to eql resource.uri_partial
     end
   end
 

--- a/spec/lib/raml_models/resource_spec.rb
+++ b/spec/lib/raml_models/resource_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Resource do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml) { Raml.parse_file(raml_file) }
+  let(:raml) { Raml::Parser.parse_file(raml_file) }
   let(:uri_partial) { raml.resources.first.first }
   let(:resource) { raml.resources.first }
 

--- a/spec/lib/raml_models/response_spec.rb
+++ b/spec/lib/raml_models/response_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Response do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml) { Raml.parse_file(raml_file) }
+  let(:raml) { Raml::Parser.parse_file(raml_file) }
   let(:response) { raml.resources.first.last.children.first.children.first }
 
   subject { described_class.new(response) }

--- a/spec/lib/raml_models/response_spec.rb
+++ b/spec/lib/raml_models/response_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Rambo::RamlModels::Response do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
   let(:raml) { Raml::Parser.parse_file(raml_file) }
-  let(:response) { raml.resources.first.last.children.first.children.first }
+  let(:response) { raml.resources.first.methods.first.responses.first }
 
   subject { described_class.new(response) }
 
   describe "#status_code" do
     it "returns the response status code" do
-      expect(subject.status_code).to eql response.name
+      expect(subject.status_code).to eql response.code
     end
   end
 

--- a/spec/lib/rspec/example_group_spec.rb
+++ b/spec/lib/rspec/example_group_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Rambo::RSpec::ExampleGroup do
   describe "#render" do
     it "interpolates the correct values" do
       aggregate_failures do
-        expect(subject.render).to include("describe \"#{raml.resources.first.methods.first.method}\" do")
+        expect(subject.render).to include("describe \"#{raml.resources.first.methods.first.method.upcase}\" do")
         expect(subject.render).to include('describe "GET" do')
       end
     end

--- a/spec/lib/rspec/example_group_spec.rb
+++ b/spec/lib/rspec/example_group_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Rambo::RSpec::ExampleGroup do
   describe "#render" do
     it "interpolates the correct values" do
       aggregate_failures do
-        expect(subject.render).to include("describe \"#{raml.resources.first.first}\" do")
+        expect(subject.render).to include("describe \"#{raml.resources.first.methods.first.method}\" do")
         expect(subject.render).to include('describe "GET" do')
       end
     end

--- a/spec/lib/rspec/example_group_spec.rb
+++ b/spec/lib/rspec/example_group_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RSpec::ExampleGroup do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml)      { Raml.parse_file(raml_file) }
+  let(:raml)      { Raml::Parser.parse_file(raml_file) }
   let(:resource)  { Rambo::RamlModels::Resource.new(raml.resources.first) }
 
   subject         { Rambo::RSpec::ExampleGroup.new(resource) }

--- a/spec/lib/rspec/example_spec.rb
+++ b/spec/lib/rspec/example_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Rambo::RSpec::Example do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml)      { Raml.parse_file(raml_file) }
+  let(:raml)      { Raml::Parser.parse_file(raml_file) }
   let(:method)    { raml.resources.first.methods.first }
 
   subject         { Rambo::RSpec::Example.new(resource: resource) }

--- a/spec/lib/rspec/examples_spec.rb
+++ b/spec/lib/rspec/examples_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RSpec::Examples do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raw_raml)  { Raml.parse_file(raml_file) }
+  let(:raw_raml)  { Raml::Parser.parse_file(raml_file) }
   let(:raml)      { Rambo::RamlModels::Api.new(raw_raml) }
 
   subject { Rambo::RSpec::Examples.new(raml) }

--- a/spec/lib/rspec/spec_file_spec.rb
+++ b/spec/lib/rspec/spec_file_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Rambo::RSpec::SpecFile do
-  let(:raw_raml)  { Raml.parse_file(raml_file) }
+  let(:raw_raml)  { Raml::Parser.parse_file(raml_file) }
   let(:raml)      { Rambo::RamlModels::Api.new(raw_raml) }
   let(:spec_file) { Rambo::RSpec::SpecFile.new(raw_raml) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require "rspec"
 require "rspec/core"
 require "rspec/matchers"
 require "rspec/expectations"
-require "raml"
+require "raml-rb"
 require "json_test_data"
 
 lib = File.expand_path("../../lib", __FILE__)

--- a/spec/support/foo.raml
+++ b/spec/support/foo.raml
@@ -1,0 +1,43 @@
+#%RAML 0.8
+---
+title: e-BookMobile API
+baseUri: http://api.e-bookmobile.com/{version}
+version: v1
+
+/authors:
+  post:
+    description: Retrieve a list of authors
+    body:
+      application/json:
+        schema: |
+          {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "description": "schema to create an author",
+            "type": "object",
+            "required": [ "first_name", "last_name" ],
+            "properties": {
+              "first_name": { "type": "string" },
+              "last_name": { "type": "string" },
+              "year_of_birth": { "type": "integer" }
+            }
+          }
+    responses:
+      200:
+        body:
+          application/json:
+            schema: |
+              {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "description": "schema for a list of authors",
+                "type": "object",
+                "properties": {
+                  "author": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer" },
+                      "first_name": { "type": "string" },
+                      "last_name": { "type": "string" }
+                    }
+                  }
+                }
+              }


### PR DESCRIPTION
This updates the required version of the raml-rb gem to 0.0.6, which has not yet been released.