### PR TITLE
Fix RSpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'pry'

--- a/spec/lib/rspec/spec_file_spec.rb
+++ b/spec/lib/rspec/spec_file_spec.rb
@@ -51,7 +51,7 @@ describe Rambo::RSpec::SpecFile do
       let(:test_data) { '"data" => 1' }
 
       it "interpolates the correct values" do
-        allow(JsonTestData).to receive(:generate).and_return({ :data => 1 })
+        allow(JsonTestData).to receive(:generate!).and_return({ :data => 1 })
         expect(spec_file.render).to include(test_data)
       end
     end

--- a/spec/lib/rspec/spec_file_spec.rb
+++ b/spec/lib/rspec/spec_file_spec.rb
@@ -51,6 +51,7 @@ describe Rambo::RSpec::SpecFile do
       let(:test_data) { '"data" => 1' }
 
       it "interpolates the correct values" do
+        allow(JsonTestData).to receive(:generate).and_return({ :data => 1 })
         expect(spec_file.render).to include(test_data)
       end
     end


### PR DESCRIPTION
This PR stubs out `JsonTestData` in the RSpec suite, so all the RSpec tests now pass. (Doing the same with the Cucumber tests will take considerably more work, but merging this PR will ensure there is at least one suite of useful tests in CI.)