### PR TITLE
Replace raml-rb gem with raml_ruby

### DIFF
--- a/lib/document_generator.rb
+++ b/lib/document_generator.rb
@@ -1,5 +1,5 @@
 require "fileutils"
-require "raml-rb"
+require "raml_parser"
 
 require File.expand_path("../rspec/spec_file.rb", __FILE__)
 require File.expand_path("../rspec/spec_helper_file.rb", __FILE__)

--- a/lib/document_generator.rb
+++ b/lib/document_generator.rb
@@ -1,5 +1,5 @@
 require "fileutils"
-require "raml_parser"
+require "raml"
 
 require File.expand_path("../rspec/spec_file.rb", __FILE__)
 require File.expand_path("../rspec/spec_helper_file.rb", __FILE__)
@@ -10,7 +10,7 @@ module Rambo
 
     def initialize(file)
       @file = file
-      @raml = RamlParser::Parser.parse_file(file)
+      @raml = Raml.parse_file(file)
     end
 
     def generate_spec_dir!

--- a/lib/document_generator.rb
+++ b/lib/document_generator.rb
@@ -10,7 +10,7 @@ module Rambo
 
     def initialize(file)
       @file = file
-      @raml = Raml::Parser.parse_file(file)
+      @raml = RamlParser::Parser.parse_file(file)
     end
 
     def generate_spec_dir!

--- a/lib/raml_models/api.rb
+++ b/lib/raml_models/api.rb
@@ -8,7 +8,7 @@ module Rambo
       end
 
       def resources
-        @resources ||= schema.resources.map {|resource| Rambo::RamlModels::Resource.new(resource) }
+        @resources ||= schema.resources.map {|uri, resource| Rambo::RamlModels::Resource.new(resource) }
       end
 
       def title

--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -10,7 +10,7 @@ module Rambo
       end
 
       def content_type
-        #
+        body.name
       end
 
       def example

--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -15,7 +15,7 @@ module Rambo
 
       def example
         example = body.example rescue body.last.example
-        @example ||= example || generate_from_schema(body.schema) || {}.to_json
+        @example ||= example || generate_from_schema(body) || {}.to_json
       end
 
       private

--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -3,10 +3,10 @@ require "json_test_data"
 module Rambo
   module RamlModels
     class Body
-      attr_reader :body
+      attr_reader :content_type, :body
 
-      def initialize(body)
-        @body = body
+      def initialize(raml)
+        @content_type, @body = raml
       end
 
       def content_type

--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -3,14 +3,10 @@ require "json_test_data"
 module Rambo
   module RamlModels
     class Body
-      attr_reader :body
+      attr_reader :content_type, :body
 
       def initialize(raml)
-        @body = raml
-      end
-
-      def content_type
-        body.name
+        @content_type, @body = raml
       end
 
       def example

--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -3,10 +3,14 @@ require "json_test_data"
 module Rambo
   module RamlModels
     class Body
-      attr_reader :content_type, :body
+      attr_reader :body
 
       def initialize(raml)
-        @content_type, @body = raml
+        @body = raml
+      end
+
+      def content_type
+        body.name
       end
 
       def example

--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -9,10 +9,6 @@ module Rambo
         @content_type, @body = raml
       end
 
-      def content_type
-        body.content_type
-      end
-
       def example
         @example ||= body.example || generate_from_schema(body.schema) || {}.to_json
       end

--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -15,12 +15,13 @@ module Rambo
 
       def example
         example = body.example rescue body.last.example
-        @example ||= example || generate_from_schema(body) || {}.to_json
+        @example ||= example || generate_from_schema || {}.to_json
       end
 
       private
 
-      def generate_from_schema(schema)
+      def generate_from_schema
+        schema = body.children.first.value
         JSON.pretty_generate(JsonTestData.generate!(schema, ruby: true))
       end
     end

--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -3,14 +3,19 @@ require "json_test_data"
 module Rambo
   module RamlModels
     class Body
-      attr_reader :content_type, :body
+      attr_reader :body
 
       def initialize(raml)
-        @content_type, @body = raml
+        @body = raml
+      end
+
+      def content_type
+        #
       end
 
       def example
-        @example ||= body.example || generate_from_schema(body.schema) || {}.to_json
+        example = body.example rescue body.last.example
+        @example ||= example || generate_from_schema(body.schema) || {}.to_json
       end
 
       private

--- a/lib/raml_models/method.rb
+++ b/lib/raml_models/method.rb
@@ -18,7 +18,6 @@ module Rambo
       end
 
       def responses
-        # puts schema.inspect
         @responses ||= schema.responses.map {|resp| Rambo::RamlModels::Response.new(resp) }
       end
     end

--- a/lib/raml_models/method.rb
+++ b/lib/raml_models/method.rb
@@ -1,16 +1,14 @@
 module Rambo
   module RamlModels
     class Method
-      attr_reader :schema, :method
+      attr_reader :method, :schema
 
       def initialize(raml_method)
-        @schema = raml_method
+        @method, @schema = raml_method
       end
 
-      alias_method :to_s, :method
-
       def request_body
-        Rambo::RamlModels::Body.new(schema.bodies.first) if schema.bodies.first
+        Rambo::RamlModels::Body.new(request_body_from_schema) if request_body_from_schema
       end
 
       def description
@@ -18,7 +16,13 @@ module Rambo
       end
 
       def responses
-        @responses ||= schema.responses.map {|resp| Rambo::RamlModels::Response.new(resp) }
+        @responses ||= schema.children.map {|resp| Rambo::RamlModels::Response.new(resp) }
+      end
+
+      private
+
+      def request_body_from_schema
+        schema.children.first.children.first
       end
     end
   end

--- a/lib/raml_models/method.rb
+++ b/lib/raml_models/method.rb
@@ -4,7 +4,7 @@ module Rambo
       attr_reader :schema, :method
 
       def initialize(raml_method)
-        @method, @schema = raml_method
+        @schema = raml_method
       end
 
       alias_method :to_s, :method
@@ -18,10 +18,9 @@ module Rambo
       end
 
       def responses
+        # puts schema.inspect
         @responses ||= schema.responses.map {|resp| Rambo::RamlModels::Response.new(resp) }
       end
-
-      alias_method :method, :to_s
     end
   end
 end

--- a/lib/raml_models/method.rb
+++ b/lib/raml_models/method.rb
@@ -1,17 +1,18 @@
 module Rambo
   module RamlModels
     class Method
-      attr_reader :schema
+      attr_reader :schema, :method
 
       def initialize(raml_method)
-        @schema = raml_method
+        @method, @schema = raml_method
       end
 
-      def to_s
-        schema.method
-      end
+      # def to_s
+      #   method
+      # end
 
       def request_body
+        puts schema.inspect
         Rambo::RamlModels::Body.new(schema.bodies.first) if schema.bodies.first
       end
 

--- a/lib/raml_models/method.rb
+++ b/lib/raml_models/method.rb
@@ -8,7 +8,7 @@ module Rambo
       end
 
       def method
-        schema.first
+        schema.name
       end
 
       def request_body

--- a/lib/raml_models/method.rb
+++ b/lib/raml_models/method.rb
@@ -7,12 +7,9 @@ module Rambo
         @method, @schema = raml_method
       end
 
-      # def to_s
-      #   method
-      # end
+      alias_method :to_s, :method
 
       def request_body
-        puts schema.inspect
         Rambo::RamlModels::Body.new(schema.bodies.first) if schema.bodies.first
       end
 

--- a/lib/raml_models/method.rb
+++ b/lib/raml_models/method.rb
@@ -1,10 +1,14 @@
 module Rambo
   module RamlModels
     class Method
-      attr_reader :method, :schema
+      attr_reader :schema
 
       def initialize(raml_method)
-        @method, @schema = raml_method
+        @schema = raml_method
+      end
+
+      def method
+        schema.first
       end
 
       def request_body

--- a/lib/raml_models/resource.rb
+++ b/lib/raml_models/resource.rb
@@ -1,21 +1,17 @@
 module Rambo
   module RamlModels
     class Resource
-      attr_reader :schema
+      attr_reader :uri_partial, :schema
 
       def initialize(raml_resource)
-        @schema = raml_resource
+        @uri_partial, @schema = raml_resource
       end
 
       def http_methods
         @http_methods ||= schema.methods.map {|method| Rambo::RamlModels::Method.new(method) }
       end
 
-      def to_s
-        schema.relative_uri
-      end
-
-      alias_method :uri_partial, :to_s
+      alias_method :to_s, :uri_partial
     end
   end
 end

--- a/lib/raml_models/resource.rb
+++ b/lib/raml_models/resource.rb
@@ -4,6 +4,7 @@ module Rambo
       attr_reader :uri_partial, :schema
 
       def initialize(raml_resource)
+        puts raml_resource.inspect
         @uri_partial, @schema = raml_resource
       end
 

--- a/lib/raml_models/resource.rb
+++ b/lib/raml_models/resource.rb
@@ -8,7 +8,7 @@ module Rambo
       end
 
       def http_methods
-        @http_methods ||= schema.methods.map {|method| Rambo::RamlModels::Method.new(method) }
+        @http_methods ||= schema.methods.map {|name, method| Rambo::RamlModels::Method.new(method) }
       end
 
       alias_method :to_s, :uri_partial

--- a/lib/raml_models/resource.rb
+++ b/lib/raml_models/resource.rb
@@ -1,10 +1,14 @@
 module Rambo
   module RamlModels
     class Resource
-      attr_reader :uri_partial, :schema
+      attr_reader :schema
 
       def initialize(raml_resource)
-        @uri_partial, @schema = raml_resource
+        @schema = raml_resource.is_a?(Array) ? raml_resource.last : raml_resource
+      end
+
+      def uri_partial
+        schema.name
       end
 
       def http_methods

--- a/lib/raml_models/resource.rb
+++ b/lib/raml_models/resource.rb
@@ -12,7 +12,7 @@ module Rambo
       end
 
       def to_s
-        schema.uri_partial
+        schema.relative_uri
       end
 
       alias_method :uri_partial, :to_s

--- a/lib/raml_models/resource.rb
+++ b/lib/raml_models/resource.rb
@@ -4,7 +4,6 @@ module Rambo
       attr_reader :uri_partial, :schema
 
       def initialize(raml_resource)
-        puts raml_resource.inspect
         @uri_partial, @schema = raml_resource
       end
 

--- a/lib/raml_models/response.rb
+++ b/lib/raml_models/response.rb
@@ -1,14 +1,14 @@
 module Rambo
   module RamlModels
     class Response
-      attr_reader :schema
+      attr_reader :status, :schema
 
       def initialize(raml)
-        @schema = raml
+        @status, @schema = raml
       end
 
       def status_code
-        schema.code
+        schema.status_code
       end
 
       def bodies

--- a/lib/raml_models/response.rb
+++ b/lib/raml_models/response.rb
@@ -1,14 +1,10 @@
 module Rambo
   module RamlModels
     class Response
-      attr_reader :status, :schema
+      attr_reader :status_code, :schema
 
       def initialize(raml)
-        @status, @schema = raml
-      end
-
-      def status_code
-        schema.status_code
+        @status_code, @schema = raml
       end
 
       def bodies

--- a/lib/raml_models/response.rb
+++ b/lib/raml_models/response.rb
@@ -12,7 +12,7 @@ module Rambo
       end
 
       def bodies
-        @bodies ||= schema.bodies.map {|body| Rambo::RamlModels::Body.new(body) }
+        @bodies ||= schema.bodies.map {|content_type, body| Rambo::RamlModels::Body.new(body) }
       end
     end
   end

--- a/lib/raml_models/response.rb
+++ b/lib/raml_models/response.rb
@@ -1,10 +1,14 @@
 module Rambo
   module RamlModels
     class Response
-      attr_reader :status_code, :schema
+      attr_reader :schema
 
       def initialize(raml)
-        @status_code, @schema = raml
+        @schema = raml
+      end
+
+      def status_code
+        schema.name
       end
 
       def bodies

--- a/lib/rspec/spec_file.rb
+++ b/lib/rspec/spec_file.rb
@@ -1,5 +1,5 @@
 require 'erb'
-require 'raml_parser'
+require 'raml'
 
 require File.expand_path('../examples.rb', __FILE__)
 require File.expand_path('../../raml_models.rb', __FILE__)

--- a/lib/rspec/spec_file.rb
+++ b/lib/rspec/spec_file.rb
@@ -1,5 +1,5 @@
 require 'erb'
-require 'raml-rb'
+require 'raml_parser'
 
 require File.expand_path('../examples.rb', __FILE__)
 require File.expand_path('../../raml_models.rb', __FILE__)

--- a/lib/rspec/templates/example_group_template.erb
+++ b/lib/rspec/templates/example_group_template.erb
@@ -1,7 +1,7 @@
   describe "<%= @resource.to_s %>" do
     let(:route) { "<%= @resource.to_s %>" }
     <%- @resource.http_methods.each do |method| %>
-    describe "<%= method.to_s.upcase %>" do
+    describe "<%= method.method.upcase %>" do
       <% if method.request_body %>let(:request_body) do<% body = method.request_body.example.split("\n") %>
         <%= body.join("\n        ").gsub(/\:/, " =>") %>.to_json
       end

--- a/lib/rspec/templates/example_group_template.erb
+++ b/lib/rspec/templates/example_group_template.erb
@@ -1,7 +1,7 @@
   describe "<%= @resource.to_s %>" do
     let(:route) { "<%= @resource.to_s %>" }
     <%- @resource.http_methods.each do |method| %>
-    describe "<%= method.method.upcase %>" do
+    describe "<%= method.to_s.upcase %>" do
       <% if method.request_body %>let(:request_body) do<% body = method.request_body.example.split("\n") %>
         <%= body.join("\n        ").gsub(/\:/, " =>") %>.to_json
       end

--- a/rambo.gemspec
+++ b/rambo.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.1.0"
 
   s.add_dependency "rspec", "~> 3.4"
-  s.add_dependency "raml_parser", "~> 0.2", ">= 0.2.5"
+  s.add_dependency "raml_ruby", "~> 0.1", ">= 0.1.2"
   s.add_dependency "rack-test", "~> 0.6"
   s.add_dependency "colorize", "~> 0.7"
   s.add_dependency "json_test_data", "~> 0.8"

--- a/rambo.gemspec
+++ b/rambo.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.1.0"
 
   s.add_dependency "rspec", "~> 3.4"
-  s.add_dependency "raml-rb", "~> 0.0.5"
+  s.add_dependency "raml_parser", "~> 0.2", ">= 0.2.5"
   s.add_dependency "rack-test", "~> 0.6"
   s.add_dependency "colorize", "~> 0.7"
   s.add_dependency "json_test_data", "~> 0.8"

--- a/spec/lib/raml_models/api_spec.rb
+++ b/spec/lib/raml_models/api_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Api do
   let(:raml_file) { File.expand_path("../../../support/multiple_resources.raml", __FILE__) }
-  let(:raml)      { RamlParser::Parser.parse_file(raml_file) }
+  let(:raml)      { Raml.parse_file(raml_file) }
 
   subject { described_class.new(raml) }
 

--- a/spec/lib/raml_models/api_spec.rb
+++ b/spec/lib/raml_models/api_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Api do
   let(:raml_file) { File.expand_path("../../../support/multiple_resources.raml", __FILE__) }
-  let(:raml)      { Raml::Parser.parse(File.read(raml_file)) }
+  let(:raml)      { RamlParser::Parser.parse_file(raml_file) }
 
   subject { described_class.new(raml) }
 

--- a/spec/lib/raml_models/body_spec.rb
+++ b/spec/lib/raml_models/body_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Body do
   let(:raml) { Raml.parse_file(raml_file) }
-  let(:body) { raml.resources.first.methods.first.last.responses.first.last.bodies.first }
+  let(:body) { raml.resources.values.first.children.first.children.first.children.first }
 
   subject { described_class.new(body) }
 
@@ -8,7 +8,7 @@ RSpec.describe Rambo::RamlModels::Body do
     let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
 
     it "returns the content type" do
-      expect(subject.content_type).to eql body.first
+      expect(subject.content_type).to eql body.name
     end
   end
 

--- a/spec/lib/raml_models/body_spec.rb
+++ b/spec/lib/raml_models/body_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Body do
   let(:raml) { RamlParser::Parser.parse_file(raml_file) }
-  let(:body) { raml.resources.first.methods.first.last.responses.first.last.bodies.first.last }
+  let(:body) { raml.resources.first.methods.first.last.responses.first.last.bodies.first }
 
   subject { described_class.new(body) }
 
@@ -8,7 +8,7 @@ RSpec.describe Rambo::RamlModels::Body do
     let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
 
     it "returns the content type" do
-      expect(subject.content_type).to eql body.content_type
+      expect(subject.content_type).to eql body.first
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe Rambo::RamlModels::Body do
       let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
 
       it "returns an example" do
-        expect(subject.example).to eql body.example
+        expect(subject.example).to eql body.last.example
       end
     end
 

--- a/spec/lib/raml_models/body_spec.rb
+++ b/spec/lib/raml_models/body_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Rambo::RamlModels::Body do
-  let(:raml) { RamlParser::Parser.parse_file(raml_file) }
+  let(:raml) { Raml.parse_file(raml_file) }
   let(:body) { raml.resources.first.methods.first.last.responses.first.last.bodies.first }
 
   subject { described_class.new(body) }

--- a/spec/lib/raml_models/body_spec.rb
+++ b/spec/lib/raml_models/body_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Body do
-  let(:raml) { Raml::Parser.parse_file(raml_file) }
-  let(:body) { raml.resources.first.methods.first.responses.first.bodies.first }
+  let(:raml) { RamlParser::Parser.parse_file(raml_file) }
+  let(:body) { raml.resources.first.methods.first.last.responses.first.last.bodies.first.last }
 
   subject { described_class.new(body) }
 

--- a/spec/lib/raml_models/body_spec.rb
+++ b/spec/lib/raml_models/body_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Rambo::RamlModels::Body do
       let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
 
       it "returns an example" do
-        expect(subject.example).to eql body.last.example
+        expect(subject.example).to eql body.example
       end
     end
 

--- a/spec/lib/raml_models/method_spec.rb
+++ b/spec/lib/raml_models/method_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Method do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml) { Raml::Parser.parse_file(raml_file) }
+  let(:raml) { RamlParser::Parser.parse_file(raml_file) }
   let(:method) { raml.resources.first.methods.first }
 
   subject { described_class.new(method) }
@@ -13,7 +13,7 @@ RSpec.describe Rambo::RamlModels::Method do
 
   describe "#description" do
     it "returns the description" do
-      expect(subject.description).to eql method.description
+      expect(subject.description).to eql method.last.description
     end
   end
 

--- a/spec/lib/raml_models/method_spec.rb
+++ b/spec/lib/raml_models/method_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Rambo::RamlModels::Method do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
   let(:raml) { Raml.parse_file(raml_file) }
-  let(:method) { raml.resources.first.methods.first }
+  let(:method) { raml.resources.first.last.children.first }
 
   subject { described_class.new(method) }
 

--- a/spec/lib/raml_models/method_spec.rb
+++ b/spec/lib/raml_models/method_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Rambo::RamlModels::Method do
 
   describe "#to_s" do
     it "returns the method name" do
-      expect(subject.to_s).to eql method.method
+      expect(subject.to_s).to eql method.first
     end
   end
 

--- a/spec/lib/raml_models/method_spec.rb
+++ b/spec/lib/raml_models/method_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Method do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml) { RamlParser::Parser.parse_file(raml_file) }
+  let(:raml) { Raml.parse_file(raml_file) }
   let(:method) { raml.resources.first.methods.first }
 
   subject { described_class.new(method) }

--- a/spec/lib/raml_models/method_spec.rb
+++ b/spec/lib/raml_models/method_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Rambo::RamlModels::Method do
 
   describe "#to_s" do
     it "returns the method name" do
-      expect(subject.to_s).to eql method.first
+      expect(subject.method).to eql method.name
     end
   end
 

--- a/spec/lib/raml_models/method_spec.rb
+++ b/spec/lib/raml_models/method_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Rambo::RamlModels::Method do
 
   describe "#description" do
     it "returns the description" do
-      expect(subject.description).to eql method.last.description
+      expect(subject.description).to eql method.description
     end
   end
 

--- a/spec/lib/raml_models/resource_spec.rb
+++ b/spec/lib/raml_models/resource_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Resource do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml) { RamlParser::Parser.parse_file(raml_file) }
+  let(:raml) { Raml.parse_file(raml_file) }
   let(:resource) { raml.resources.first }
 
   subject { described_class.new(resource) }

--- a/spec/lib/raml_models/resource_spec.rb
+++ b/spec/lib/raml_models/resource_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Rambo::RamlModels::Resource do
 
   describe "#uri_partial" do
     it "returns the URI partial" do
-      expect(subject.uri_partial).to eql resource.relative_uri
+      expect(subject.uri_partial).to eql resource.first
     end
   end
 

--- a/spec/lib/raml_models/resource_spec.rb
+++ b/spec/lib/raml_models/resource_spec.rb
@@ -1,13 +1,14 @@
 RSpec.describe Rambo::RamlModels::Resource do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
   let(:raml) { Raml.parse_file(raml_file) }
+  let(:uri_partial) { raml.resources.first.first }
   let(:resource) { raml.resources.first }
 
   subject { described_class.new(resource) }
 
   describe "#to_s" do
     it "returns the URI partial" do
-      expect(subject.to_s).to eql resource.relative_uri
+      expect(subject.to_s).to eql uri_partial
     end
   end
 

--- a/spec/lib/raml_models/resource_spec.rb
+++ b/spec/lib/raml_models/resource_spec.rb
@@ -1,19 +1,19 @@
 RSpec.describe Rambo::RamlModels::Resource do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml) { Raml::Parser.parse_file(raml_file) }
+  let(:raml) { RamlParser::Parser.parse_file(raml_file) }
   let(:resource) { raml.resources.first }
 
   subject { described_class.new(resource) }
 
   describe "#to_s" do
     it "returns the URI partial" do
-      expect(subject.to_s).to eql resource.uri_partial
+      expect(subject.to_s).to eql resource.relative_uri
     end
   end
 
   describe "#uri_partial" do
     it "returns the URI partial" do
-      expect(subject.uri_partial).to eql resource.uri_partial
+      expect(subject.uri_partial).to eql resource.relative_uri
     end
   end
 

--- a/spec/lib/raml_models/response_spec.rb
+++ b/spec/lib/raml_models/response_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Rambo::RamlModels::Response do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
   let(:raml) { Raml.parse_file(raml_file) }
-  let(:response) { raml.resources.first.methods.first.last.responses.first }
+  let(:response) { raml.resources.first.last.children.first.children.first }
 
   subject { described_class.new(response) }
 
   describe "#status_code" do
     it "returns the response status code" do
-      expect(subject.status_code).to eql response.first
+      expect(subject.status_code).to eql response.name
     end
   end
 

--- a/spec/lib/raml_models/response_spec.rb
+++ b/spec/lib/raml_models/response_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Response do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml) { Raml::Parser.parse_file(raml_file) }
+  let(:raml) { RamlParser::Parser.parse_file(raml_file) }
   let(:response) { raml.resources.first.methods.first.responses.first }
 
   subject { described_class.new(response) }

--- a/spec/lib/raml_models/response_spec.rb
+++ b/spec/lib/raml_models/response_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RamlModels::Response do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml) { RamlParser::Parser.parse_file(raml_file) }
+  let(:raml) { Raml.parse_file(raml_file) }
   let(:response) { raml.resources.first.methods.first.last.responses.first }
 
   subject { described_class.new(response) }

--- a/spec/lib/raml_models/response_spec.rb
+++ b/spec/lib/raml_models/response_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Rambo::RamlModels::Response do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
   let(:raml) { RamlParser::Parser.parse_file(raml_file) }
-  let(:response) { raml.resources.first.methods.first.responses.first }
+  let(:response) { raml.resources.first.methods.first.last.responses.first }
 
   subject { described_class.new(response) }
 
   describe "#status_code" do
     it "returns the response status code" do
-      expect(subject.status_code).to eql response.code
+      expect(subject.status_code).to eql response.first
     end
   end
 

--- a/spec/lib/rspec/example_group_spec.rb
+++ b/spec/lib/rspec/example_group_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Rambo::RSpec::ExampleGroup do
   describe "#render" do
     it "interpolates the correct values" do
       aggregate_failures do
-        expect(subject.render).to include("describe \"#{raml.resources.first.relative_uri}\" do")
+        expect(subject.render).to include("describe \"#{raml.resources.first.first}\" do")
         expect(subject.render).to include('describe "GET" do')
       end
     end

--- a/spec/lib/rspec/example_group_spec.rb
+++ b/spec/lib/rspec/example_group_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RSpec::ExampleGroup do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml)      { Raml::Parser.parse(File.read(raml_file)) }
+  let(:raml)      { RamlParser::Parser.parse_file(raml_file) }
   let(:resource)  { Rambo::RamlModels::Resource.new(raml.resources.first) }
 
   subject         { Rambo::RSpec::ExampleGroup.new(resource) }

--- a/spec/lib/rspec/example_group_spec.rb
+++ b/spec/lib/rspec/example_group_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RSpec::ExampleGroup do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml)      { RamlParser::Parser.parse_file(raml_file) }
+  let(:raml)      { Raml.parse_file(raml_file) }
   let(:resource)  { Rambo::RamlModels::Resource.new(raml.resources.first) }
 
   subject         { Rambo::RSpec::ExampleGroup.new(resource) }

--- a/spec/lib/rspec/example_group_spec.rb
+++ b/spec/lib/rspec/example_group_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Rambo::RSpec::ExampleGroup do
   describe "#render" do
     it "interpolates the correct values" do
       aggregate_failures do
-        expect(subject.render).to include("describe \"#{raml.resources.first.uri_partial}\" do")
+        expect(subject.render).to include("describe \"#{raml.resources.first.relative_uri}\" do")
         expect(subject.render).to include('describe "GET" do')
       end
     end

--- a/spec/lib/rspec/example_spec.rb
+++ b/spec/lib/rspec/example_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Rambo::RSpec::Example do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml)      { RamlParser::Parser.parse_file(raml_file) }
+  let(:raml)      { Raml.parse_file(raml_file) }
   let(:method)    { raml.resources.first.methods.first }
 
   subject         { Rambo::RSpec::Example.new(resource: resource) }

--- a/spec/lib/rspec/example_spec.rb
+++ b/spec/lib/rspec/example_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Rambo::RSpec::Example do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raml)      { Raml::Parser.parse(File.read(raml_file)) }
+  let(:raml)      { RamlParser::Parser.parse_file(raml_file) }
   let(:method)    { raml.resources.first.methods.first }
 
   subject         { Rambo::RSpec::Example.new(resource: resource) }

--- a/spec/lib/rspec/examples_spec.rb
+++ b/spec/lib/rspec/examples_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RSpec::Examples do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raw_raml)  { Raml::Parser.parse(File.read(raml_file)) }
+  let(:raw_raml)  { RamlParser::Parser.parse_file(raml_file) }
   let(:raml)      { Rambo::RamlModels::Api.new(raw_raml) }
 
   subject { Rambo::RSpec::Examples.new(raml) }

--- a/spec/lib/rspec/examples_spec.rb
+++ b/spec/lib/rspec/examples_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::RSpec::Examples do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
-  let(:raw_raml)  { RamlParser::Parser.parse_file(raml_file) }
+  let(:raw_raml)  { Raml.parse_file(raml_file) }
   let(:raml)      { Rambo::RamlModels::Api.new(raw_raml) }
 
   subject { Rambo::RSpec::Examples.new(raml) }

--- a/spec/lib/rspec/spec_file_spec.rb
+++ b/spec/lib/rspec/spec_file_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Rambo::RSpec::SpecFile do
-  let(:raw_raml)  { Raml::Parser.parse(File.read(raml_file)) }
+  let(:raw_raml)  { RamlParser::Parser.parse_file(raml_file) }
   let(:raml)      { Rambo::RamlModels::Api.new(raw_raml) }
   let(:spec_file) { Rambo::RSpec::SpecFile.new(raw_raml) }
 

--- a/spec/lib/rspec/spec_file_spec.rb
+++ b/spec/lib/rspec/spec_file_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Rambo::RSpec::SpecFile do
       end
 
       it "uses the correct schema" do
-        puts spec_file.raml.schema
         expect(spec_file.raml.schema).to eq raw_raml
       end
     end

--- a/spec/lib/rspec/spec_file_spec.rb
+++ b/spec/lib/rspec/spec_file_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Rambo::RSpec::SpecFile do
-  let(:raw_raml)  { RamlParser::Parser.parse_file(raml_file) }
+  let(:raw_raml)  { Raml.parse_file(raml_file) }
   let(:raml)      { Rambo::RamlModels::Api.new(raw_raml) }
   let(:spec_file) { Rambo::RSpec::SpecFile.new(raw_raml) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require "rspec"
 require "rspec/core"
 require "rspec/matchers"
 require "rspec/expectations"
-require "raml-rb"
+require "raml_parser"
 require "json_test_data"
 
 lib = File.expand_path("../../lib", __FILE__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require "rspec"
 require "rspec/core"
 require "rspec/matchers"
 require "rspec/expectations"
-require "raml_parser"
+require "raml"
 require "json_test_data"
 
 lib = File.expand_path("../../lib", __FILE__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,5 +11,10 @@ require "json_test_data"
 
 lib = File.expand_path("../../lib", __FILE__)
 SPEC_DIR_ROOT = File.expand_path("../", __FILE__)
+
 Dir.foreach("#{lib}")   {|f| require f if f.match(/.*\.rb\z/) }
-RSpec.configure { |c| c.disable_monkey_patching! }
+
+RSpec.configure do |c|
+  c.disable_monkey_patching!
+  c.order = :random
+end


### PR DESCRIPTION
The raml-rb gem is incomplete and as a consequence needed to be replaced with a more complete RAML parser. This PR replaces raml-rb with raml_ruby.