### PR TITLE
Fix bug 37

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -3,8 +3,9 @@ require File.expand_path("../document_generator.rb", __FILE__)
 
 module Rambo
   class CLI
-    def initialize(raml_file=nil, stdout=STDOUT)
+    def initialize(raml_file=nil, stdout=STDOUT, stderr=STDERR)
       @stdout = stdout
+      @stderr = stderr
       @file   = raml_file
 
       validate!
@@ -23,8 +24,8 @@ module Rambo
         generator.generate_spec_file!
         stdout.puts("Done!".green)
       rescue NoMethodError => e
-        stdout.puts("Error: #{e.message}\n".red)
-        stdout.puts e.backtrace.join("\n\t")
+        stderr.puts("Error: #{e.message}".red)
+        stderr.puts "\t#{e.backtrace.join("\n\t")}"
       end
     end
 
@@ -35,7 +36,7 @@ module Rambo
 
     private
 
-    attr_accessor :file, :stdout, :generator
+    attr_accessor :file, :stdout, :stderr, :generator
 
     def print_logo
       stdout.puts logo.colorize(color: String.colors.sample)

--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -20,6 +20,7 @@ module Rambo
       private
 
       def generate_from_schema
+        return nil unless body.schema
         JSON.pretty_generate(JsonTestData.generate!(body.schema, ruby: true))
       end
     end

--- a/lib/raml_models/method.rb
+++ b/lib/raml_models/method.rb
@@ -12,7 +12,7 @@ module Rambo
       end
 
       def request_body
-        Rambo::RamlModels::Body.new(request_body_from_schema) if has_request_body?
+        Rambo::RamlModels::Body.new(schema.bodies.first) if has_request_body?
       end
 
       def description
@@ -26,12 +26,7 @@ module Rambo
       private
 
       def has_request_body?
-        schema.bodies.first != nil
-      end
-
-      def request_body_from_schema
-        return unless schema.bodies.first
-        schema.bodies.first.example || JSON.pretty_generate(JsonTestData.generate!(schema.bodies.first.schema, ruby: true))
+        !!schema.bodies.first
       end
     end
   end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Rambo::CLI do
   let(:valid_file) { File.expand_path('../../support/foobar.raml', __FILE__) }
 
   describe "run!" do
-    let(:cli) { Rambo::CLI.new(valid_file, io) }
+    let(:cli) { Rambo::CLI.new(valid_file, io, STDERR) }
 
     it "creates a spec/contract directory" do
       allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_rambo_helper!)
@@ -25,6 +25,18 @@ RSpec.describe Rambo::CLI do
       allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_dir!)
       expect_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_file!)
       cli.run!
+    end
+
+    context "when there is an error" do
+      it "prints the error messaage" do
+        allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_rambo_helper!)
+        allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_dir!)
+        allow_any_instance_of(Rambo::DocumentGenerator)
+          .to receive(:generate_spec_file!)
+          .and_raise NoMethodError, "Undefined method generate_spec_file!"
+
+        expect{ cli.run! }.to rescue(NoMethodError)
+      end
     end
   end
 


### PR DESCRIPTION
This ensures that a `Raml::Body` object is passed into the initializer of the `Rambo::RamlModels::Body` class, fixing #37.