### PR TITLE
Fix bug 43

### DIFF
--- a/lib/document_generator.rb
+++ b/lib/document_generator.rb
@@ -31,7 +31,7 @@ module Rambo
     end
 
     def generate_matcher_dir!
-      FileUtils.mkdir_p("spec/support/matchers") && FileUtils.touch("spec/support/matchers/rambo_matchers.rb")
+      FileUtils.mkdir_p("spec/support/matchers")
     end
 
     def generate_matchers!


### PR DESCRIPTION
This PR ensures that the expected contents are written to `spec/support/matchers/rambo_matchers.rb`, correcting bug #43. 