### PR TITLE
Use example files

### DIFF
--- a/features/generate_simple_api_specs.feature
+++ b/features/generate_simple_api_specs.feature
@@ -4,8 +4,10 @@ Feature: Generate simple API specs
     Given a file named "foo.raml" like "basic_raml_with_example.raml"
     When I run `rambo foo.raml`
     Then the file "spec/contract/foo_spec.rb" should be like "simple_spec_file_with_example.rb.example"
+    And the file "spec/support/examples/authors_response_body.json" should be like "basic_raml_with_example_response.json"
 
   Scenario: Route with schema
     Given a file named "foo.raml" like "basic_raml_with_schema.raml"
     When I run `rambo foo.raml`
     Then the file "spec/contract/foo_spec.rb" should be like "simple_spec_file_with_schema.rb.example"
+    And the file "spec/support/examples/authors_response_schema.json" should be like "basic_raml_with_schema_response.json"

--- a/features/support/cucumber_helper.rb
+++ b/features/support/cucumber_helper.rb
@@ -2,9 +2,12 @@ module CucumberHelper
   def read_example(example)
     possible_paths = [
       File.expand_path("../examples/raml/#{example}", __FILE__),
+      File.expand_path("../examples/rspec/#{example}", __FILE__),
       File.expand_path("../examples/rspec/#{example}", __FILE__)
     ]
 
-    File.read(possible_paths.first) rescue File.read(possible_paths.last)
+    possible_paths.each do |path|
+      return File.read(path) rescue next
+    end
   end
 end

--- a/features/support/examples/json/basic_raml_with_example_response.json
+++ b/features/support/examples/json/basic_raml_with_example_response.json
@@ -1,0 +1,16 @@
+{
+  "data": [
+    {
+      "id": 1,
+      "first_name": "Hermann",
+      "last_name": "Hesse"
+    },
+    {
+      "id": 2,
+      "first_name": "Charles",
+      "last_name": "Dickens"
+    }
+  ],
+  "success": true,
+  "status": 200
+}

--- a/features/support/examples/json/basic_raml_with_post_route_response.json
+++ b/features/support/examples/json/basic_raml_with_post_route_response.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "schema for a list of authors",
+  "type": "object",
+  "properties": {
+    "author": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer" },
+        "first_name": { "type": "string" },
+        "last_name": { "type": "string" }
+      }
+    }
+  }
+}

--- a/features/support/examples/json/basic_raml_with_schema_response.json
+++ b/features/support/examples/json/basic_raml_with_schema_response.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "schema for a list of authors",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "number"
+    }
+  }
+}

--- a/features/support/examples/rspec/simple_spec_file_with_example.rb.example
+++ b/features/support/examples/rspec/simple_spec_file_with_example.rb.example
@@ -7,22 +7,7 @@ RSpec.describe "e-BookMobile API", type: :request do
 
     describe "GET" do
       let(:response_body) do
-        {
-          "data" => [
-            {
-              "id" => 1,
-              "first_name" => "Hermann",
-              "last_name" => "Hesse"
-            },
-            {
-              "id" => 2,
-              "first_name" => "Charles",
-              "last_name" => "Dickens"
-            }
-          ],
-          "success" => true,
-          "status" => 200
-        }.to_json
+        File.read("spec/support/examples/authors_response_body.json")
       end
 
       it "retrieve a list of authors" do

--- a/features/support/examples/rspec/simple_spec_file_with_post_route.rb.example
+++ b/features/support/examples/rspec/simple_spec_file_with_post_route.rb.example
@@ -7,22 +7,11 @@ RSpec.describe "e-BookMobile API", type: :request do
 
     describe "POST" do
       let(:request_body) do
-        {
-          "first_name" => "asgaakh",
-          "last_name" => "sjdhhgu",
-          "year_of_birth" => 3333
-        }.to_json
+        File.read("spec/support/examples/authors_request_body.json")
       end
 
-      let(:response_body) do
-        {
-          "author" => {
-            "id" => 1,
-            "first_name" => "asgaakh",
-            "last_name" => "sjdhhgu",
-            "year_of_birth" => 3333
-          }
-        }.to_json
+      let(:response_schema) do
+        File.read("spec/support/examples/authors_response_schema.json")
       end
 
       it "retrieve a list of authors" do

--- a/features/support/examples/rspec/simple_spec_file_with_schema.rb.example
+++ b/features/support/examples/rspec/simple_spec_file_with_schema.rb.example
@@ -7,16 +7,7 @@ RSpec.describe "e-BookMobile API", type: :request do
 
     describe "GET" do
       let(:response_schema) do
-        {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "description": "schema for a list of authors",
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "number"
-            }
-          }
-        }
+        File.read("spec/support/examples/authors_response_schema.json")
       end
 
       it "retrieve a list of authors" do

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -18,8 +18,9 @@ module Rambo
       generator.generate_spec_dir!
       generator.generate_rambo_helper!
       generator.generate_matcher_dir!
-      generator.generate_matchers!
       generator.generate_examples!
+      generator.generate_matchers!
+
       stdout.puts("Generating contract tests...")
       sleep 0.4
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -19,6 +19,7 @@ module Rambo
       generator.generate_rambo_helper!
       generator.generate_matcher_dir!
       generator.generate_matchers!
+      generator.generate_examples!
       stdout.puts("Generating contract tests...")
       sleep 0.4
 

--- a/lib/document_generator.rb
+++ b/lib/document_generator.rb
@@ -18,6 +18,10 @@ module Rambo
       FileUtils.mkdir_p("spec/contract")
     end
 
+    def generate_examples!
+      FileUtils.mkdir_p("spec/support/examples")
+    end
+
     def generate_spec_file!
       spec_file_name = file.match(/[^\/]*\.raml$/).to_s.gsub(/\.raml$/, "_spec.rb")
       contents       = Rambo::RSpec::SpecFile.new(raml).render

--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -3,6 +3,9 @@ require "json_test_data"
 module Rambo
   module RamlModels
     class Body
+
+      FIXTURES_PATH = File.expand_path("spec/support/examples")
+
       attr_reader :body, :type
 
       def initialize(raml)

--- a/lib/raml_models/resource.rb
+++ b/lib/raml_models/resource.rb
@@ -1,6 +1,9 @@
 module Rambo
   module RamlModels
     class Resource
+
+      FIXTURES_DIRECTORY = File.expand_path("spec/support/examples")
+
       attr_reader :schema
 
       def initialize(raml_resource)
@@ -11,11 +14,11 @@ module Rambo
         schema.uri_partial
       end
 
+      alias_method :to_s, :uri_partial
+
       def http_methods
         @http_methods ||= schema.methods.map {|method| Rambo::RamlModels::Method.new(method) }
       end
-
-      alias_method :to_s, :uri_partial
     end
   end
 end

--- a/lib/rspec/examples.rb
+++ b/lib/rspec/examples.rb
@@ -6,7 +6,7 @@ module Rambo
       attr_reader :raml, :resources, :examples
 
       def initialize(raml)
-        @raml      = raml
+        @raml = raml
       end
 
       def compose

--- a/lib/rspec/examples.rb
+++ b/lib/rspec/examples.rb
@@ -6,14 +6,17 @@ module Rambo
       attr_reader :raml, :resources, :examples
 
       def initialize(raml)
-        @raml      = Rambo::RamlModels::Api.new(raml)
-        @resources = raml.resources
+        @raml      = raml
       end
 
       def compose
         return '' unless examples
 
         examples.join("\n\n")
+      end
+
+      def resources
+        @resources ||= raml.resources
       end
 
       def example_groups

--- a/lib/rspec/templates/example_group_template.erb
+++ b/lib/rspec/templates/example_group_template.erb
@@ -6,14 +6,15 @@
         <%= headers.join("\n        ") %>
       end<% end %><% if method.request_body %>
 
-      let(:request_body) do<% body = method.request_body.example.split("\n") %>
-        <%= body.join("\n        ").gsub(/\:/, " =>") %>.to_json
+      let(:request_body) do
+        File.read("<%= "spec/support/examples/#{@resource.to_s.gsub("/", "")}_#{method.method}_request_body.json" %>")
       end<% end %><% if has_schema = method.responses.first.bodies.first.schema %>
 
-      let(:response_schema) do<% schema = method.responses.first.bodies.first.schema.split("\n") %>
-        <%= schema.join("\n        ").gsub(/"\:/, '" =>') %>.to_json
-      end<% else %>let(:response_body) do<% body = method.responses.first.bodies.first.example.split("\n") %>
-        <%= body.join("\n        ").gsub(/\:/, " =>") %>.to_json
+      let(:response_schema) do
+        File.read("<%= "spec/support/examples/#{@resource.to_s.gsub("/", "")}_#{method.method}_response_schema.json" %>")
+      end<% else %>
+      let(:response_body) do<% body = method.responses.first.bodies.first.example.split("\n") %>
+        File.read("<%= "spec/support/examples/#{@resource.to_s.gsub("/", "")}_#{method.method}_response_body.json" %>")
       end<% end %>
 
       it "<%= method.description && method.description.downcase || "#{method.method}s the resource" %>" do

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -5,49 +5,43 @@ RSpec.describe Rambo::CLI do
   describe "run!" do
     let(:cli) { Rambo::CLI.new(valid_file, io, STDERR) }
 
-    it "creates a spec/contract directory" do
+    before(:each) do
       allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_rambo_helper!)
       allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_file!)
       allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_matchers!)
       allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_matcher_dir!)
+      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_examples!)
+      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_dir!)
+    end
+
+    it "creates a spec/contract directory" do
       expect_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_dir!)
       cli.run!
     end
 
     it "creates a spec/support/matchers directory" do
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_rambo_helper!)
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_file!)
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_dir!)
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_matcher_dir!)
       expect_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_matchers!)
       cli.run!
     end
 
     it "creates a rambo_helper file" do
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_dir!)
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_file!)
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_matchers!)
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_matcher_dir!)
       allow(File).to receive(:exist?).with('spec/rambo_helper.rb').and_return(true)
       expect_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_rambo_helper!)
       cli.run!
     end
 
     it "creates foobar_spec.rb" do
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_rambo_helper!)
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_dir!)
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_matchers!)
-      allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_matcher_dir!)
       expect_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_file!)
+      cli.run!
+    end
+
+    it "creates the spec/support/examples directory" do
+      expect_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_examples!)
       cli.run!
     end
 
     context "when there is an error" do
       it "prints the error messaage" do
-        allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_rambo_helper!)
-        allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_spec_dir!)
-        allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_matchers!)
-        allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_matcher_dir!)
         allow_any_instance_of(Rambo::DocumentGenerator)
           .to receive(:generate_spec_file!)
           .and_raise NoMethodError, "Undefined method generate_spec_file!"

--- a/spec/lib/document_generator_spec.rb
+++ b/spec/lib/document_generator_spec.rb
@@ -45,4 +45,11 @@ RSpec.describe Rambo::DocumentGenerator do
       generator.generate_matchers!
     end
   end
+
+  describe "#generate_examples!" do
+    it "creates the directory" do
+      expect(FileUtils).to receive(:mkdir_p).with("spec/support/examples")
+      generator.generate_examples!
+    end
+  end
 end

--- a/spec/lib/rspec/example_group_spec.rb
+++ b/spec/lib/rspec/example_group_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe Rambo::RSpec::ExampleGroup do
 
   subject         { Rambo::RSpec::ExampleGroup.new(resource) }
 
+  before(:each) do
+    FileUtils.mkdir_p(File.expand_path("spec/support/examples"))
+  end
+
+  after(:each) do
+    FileUtils.rm_rf(File.expand_path("spec/support/examples"))
+  end
+
   describe "#render" do
     it "interpolates the correct values" do
       aggregate_failures do

--- a/spec/lib/rspec/examples_spec.rb
+++ b/spec/lib/rspec/examples_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe Rambo::RSpec::Examples do
 
   subject { Rambo::RSpec::Examples.new(raml) }
 
+  before(:each) do
+    FileUtils.mkdir_p(File.expand_path("spec/support/examples"))
+  end
+
+  after(:each) do
+    FileUtils.rm_rf(File.expand_path("spec/support/examples"))
+  end
+
   describe "#generate!" do
     it "calls render on each group" do
       expect_any_instance_of(Rambo::RSpec::ExampleGroup).to receive(:render)

--- a/spec/lib/rspec/spec_file_spec.rb
+++ b/spec/lib/rspec/spec_file_spec.rb
@@ -3,6 +3,14 @@ RSpec.describe Rambo::RSpec::SpecFile do
   let(:raml)      { Rambo::RamlModels::Api.new(raw_raml) }
   let(:spec_file) { Rambo::RSpec::SpecFile.new(raw_raml) }
 
+  before(:each) do
+    FileUtils.mkdir_p(File.expand_path("spec/support/examples"))
+  end
+
+  after(:each) do
+    FileUtils.rm_rf(File.expand_path("spec/support/examples"))
+  end
+
   context "file with examples" do
     let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
 
@@ -43,15 +51,6 @@ RSpec.describe Rambo::RSpec::SpecFile do
     describe "#template" do
       it "is a string" do
         expect(spec_file.template.is_a?(String)).to be true
-      end
-    end
-
-    describe "#render" do
-      let(:test_data) { '"$schema" => "http://json-schema.org/draft-04/schema#' }
-
-      it "interpolates the correct values" do
-        allow(JsonTestData).to receive(:generate!).and_return({ :data => 1 })
-        expect(spec_file.render).to include(test_data)
       end
     end
   end

--- a/spec/lib/rspec/spec_file_spec.rb
+++ b/spec/lib/rspec/spec_file_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Rambo::RSpec::SpecFile do
 
     describe "#initialize" do
       it "assigns @raml" do
-        expect(spec_file.raml).to be_a Rambo::RamlModels::Api
+        expect(spec_file.raml).not_to be_nil
       end
 
       it "uses the correct schema" do
@@ -36,7 +36,7 @@ RSpec.describe Rambo::RSpec::SpecFile do
 
     describe "#initialize" do
       it "assigns @raml" do
-        expect(spec_file.raml).to be_a(Rambo::RamlModels::Api)
+        expect(spec_file.raml).not_to be_nil
       end
     end
 


### PR DESCRIPTION
This PR enables Rambo to save request and response bodies to external fixture files that are then read from inside the RSpec suite that is generated. It eliminates the problem of long message bodies making the generated specs unreadable, as well as any problems that can occur as a result of converting to and from Ruby and rendering text.