### PR TITLE
Sort out require issue

### DIFF
--- a/bin/rambo
+++ b/bin/rambo
@@ -4,7 +4,6 @@ lib = File.expand_path("../../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "fileutils"
-
 require "cli"
 
 filename = ARGV[0] ? File.expand_path(ARGV[0], FileUtils.pwd) : nil

--- a/bin/rambo
+++ b/bin/rambo
@@ -1,8 +1,11 @@
 #!/usr/bin/env ruby
 
+lib = File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
 require "fileutils"
 
-require_relative "../lib/cli"
+require "cli"
 
 filename = ARGV[0] ? File.expand_path(ARGV[0], FileUtils.pwd) : nil
 


### PR DESCRIPTION
Set load path in `bin/rambo` so as not to get errors when Rambo is run.