### PR TITLE
Use schemas instead of generating

### DIFF
--- a/lib/raml_models/body.rb
+++ b/lib/raml_models/body.rb
@@ -4,8 +4,6 @@ module Rambo
   module RamlModels
     class Body
 
-      FIXTURES_PATH = File.expand_path("spec/support/examples")
-
       attr_reader :body, :type
 
       def initialize(raml)

--- a/lib/raml_models/resource.rb
+++ b/lib/raml_models/resource.rb
@@ -2,8 +2,6 @@ module Rambo
   module RamlModels
     class Resource
 
-      FIXTURES_DIRECTORY = File.expand_path("spec/support/examples")
-
       attr_reader :schema
 
       def initialize(raml_resource)

--- a/lib/rspec/example_group.rb
+++ b/lib/rspec/example_group.rb
@@ -23,8 +23,9 @@ module Rambo
 
           method.responses.each do |resp|
             resp.bodies.each do |body|
-              path = body.schema ? response_schema_fixture_path(method) : response_body_fixture_path(method)
-              File.write(path, body.example)
+              path     = body.schema ? response_schema_fixture_path(method) : response_body_fixture_path(method)
+              contents = body.schema ? body.schema : body.example
+              File.write(path, contents)
             end
           end
         end


### PR DESCRIPTION
This fixes a bug where Rambo was generating example JSON objects instead of using schemas when schemas were available. Now, if there is a schema for a given response body, the actual response body will be matched against the schema, with an example only being used if no schema is given.