### PR TITLE
Update JSON Test Data gem

### DIFF
--- a/rambo.gemspec
+++ b/rambo.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "raml-rb", "~> 0.0.6"
   s.add_dependency "rack-test", "~> 0.6"
   s.add_dependency "colorize", "~> 0.7"
-  s.add_dependency "json_test_data", "~> 0.9"
+  s.add_dependency "json_test_data", "~> 1.0"
   s.add_dependency "json-schema", "~> 2.6"
 
   s.add_development_dependency "cucumber", "~> 2.1"


### PR DESCRIPTION
This PR updates JSON Test Data to version 1.0, which allows Rambo to support the JSON Schema v. 4 `oneOf` property.