### PR TITLE
54 output response bodies

### DIFF
--- a/features/support/examples/rspec/simple_spec_file_with_example.rb.example
+++ b/features/support/examples/rspec/simple_spec_file_with_example.rb.example
@@ -7,11 +7,18 @@ RSpec.describe "e-BookMobile API", type: :request do
 
     describe "GET" do
       let(:response_body) do
-        File.read("spec/support/examples/authors_response_body.json")
+        File.read("spec/support/examples/authors_get_response_body.json")
+      end
+
+      let(:output_file) do
+        "spec/contract/output/authors_get_response.json"
       end
 
       it "retrieve a list of authors" do
         get route
+
+        File.open(output_file, "w+") {|file| file.puts JSON.pretty_generate(JSON.parse(response.body)) }
+
         expect(response.body).to eql response_body
       end
 

--- a/features/support/examples/rspec/simple_spec_file_with_post_route.rb.example
+++ b/features/support/examples/rspec/simple_spec_file_with_post_route.rb.example
@@ -7,15 +7,22 @@ RSpec.describe "e-BookMobile API", type: :request do
 
     describe "POST" do
       let(:request_body) do
-        File.read("spec/support/examples/authors_request_body.json")
+        File.read("spec/support/examples/authors_post_request_body.json")
       end
 
       let(:response_schema) do
-        File.read("spec/support/examples/authors_response_schema.json")
+        File.read("spec/support/examples/authors_post_response_schema.json")
+      end
+
+      let(:output_file) do
+        "spec/contract/output/authors_post_response.json"
       end
 
       it "retrieve a list of authors" do
         get route
+
+        File.open(output_file, "w+") {|file| file.puts(JSON.pretty_generate(JSON.parse(response.body))) }
+
         expect(response.body).to eql response_body
       end
 

--- a/features/support/examples/rspec/simple_spec_file_with_schema.rb.example
+++ b/features/support/examples/rspec/simple_spec_file_with_schema.rb.example
@@ -10,8 +10,15 @@ RSpec.describe "e-BookMobile API", type: :request do
         File.read("spec/support/examples/authors_response_schema.json")
       end
 
+      let(:output_file) do
+        "spec/contract/output/authors_get_response.json"
+      end
+
       it "retrieve a list of authors" do
         get route
+
+        File.open(output_file, "w+") {|file| file.puts JSON.pretty_generate(JSON.parse(response.body)) }
+
         expect(response.body).to match_schema response_schema
       end
 

--- a/features/support/examples/rspec/spec_file_with_request_headers.rb.example
+++ b/features/support/examples/rspec/spec_file_with_request_headers.rb.example
@@ -31,8 +31,15 @@ RSpec.describe "e-BookMobile API", type: :request do
         }.to_json
       end
 
+      let(:output_file) do
+        "spec/contract/output/authors_get_response.json"
+      end
+
       it "retrieve a list of authors" do
         get route
+
+        File.open(output_file, "w+") {|file| file.puts JSON.pretty_generate(JSON.parse(response.body)) }
+
         expect(response.body).to eql response_body
       end
 

--- a/lib/document_generator.rb
+++ b/lib/document_generator.rb
@@ -14,7 +14,7 @@ module Rambo
     end
 
     def generate_spec_dir!
-      FileUtils.mkdir_p("spec/contract")
+      FileUtils.mkdir_p("spec/contract/output")
     end
 
     def generate_examples!

--- a/lib/rspec/templates/example_group_template.erb
+++ b/lib/rspec/templates/example_group_template.erb
@@ -23,6 +23,9 @@
 
       it "<%= method.description && method.description.downcase || "#{method.method}s the resource" %>" do
         <%= method.method %> route<% if method.request_body %>, request_body<% end %><% if method.headers %>, headers<% end %>
+
+        File.open(output_file, "w+") {|file| file.puts JSON.pretty_generate(JSON.parse(response.body)) }
+
         expect(response.body).to <%= has_schema ? "match_schema response_schema" : "eql response_body" %>
       end
 

--- a/lib/rspec/templates/example_group_template.erb
+++ b/lib/rspec/templates/example_group_template.erb
@@ -17,6 +17,10 @@
         File.read("<%= "spec/support/examples/#{@resource.to_s.gsub("/", "")}_#{method.method}_response_body.json" %>")
       end<% end %>
 
+      let(:output_file) do
+        "<%= "spec/contract/output/#{@resource.to_s.gsub("/", "")}_#{method.method}_response.json" %>"
+      end
+
       it "<%= method.description && method.description.downcase || "#{method.method}s the resource" %>" do
         <%= method.method %> route<% if method.request_body %>, request_body<% end %><% if method.headers %>, headers<% end %>
         expect(response.body).to <%= has_schema ? "match_schema response_schema" : "eql response_body" %>

--- a/lib/rspec/templates/spec_file_template.erb
+++ b/lib/rspec/templates/spec_file_template.erb
@@ -1,6 +1,15 @@
 require "rambo_helper"
 
 RSpec.describe "<%= @raml.title %>", type: :request do
+
+  # Delete output files from previous test run prior to running tests again
+  before(:all) do
+    Dir.foreach("spec/contract/output") do |file|
+      next unless file.match(/\.json$/)
+
+      File.delete(File.join("spec/contract/output", file))
+    end
+  end
 <%- if @examples.generate! && @examples.compose.size > 0 %>
 <%= @examples.compose.chomp %><%- end %>
 end

--- a/spec/lib/document_generator_spec.rb
+++ b/spec/lib/document_generator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Rambo::DocumentGenerator do
 
   describe "#generate_spec_dir!" do
     it "generates the spec/contract directory" do
-      expect(FileUtils).to receive(:mkdir_p).with("spec/contract")
+      expect(FileUtils).to receive(:mkdir_p).with("spec/contract/output")
       generator.generate_spec_dir!
     end
   end

--- a/spec/lib/rspec/example_group_spec.rb
+++ b/spec/lib/rspec/example_group_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Rambo::RSpec::ExampleGroup do
   describe "#render" do
     it "interpolates the correct values" do
       aggregate_failures do
+        expect(subject.render).to include("let(:output_file) do")
         expect(subject.render).to include("describe \"#{raml.resources.first.methods.first.method.upcase}\" do")
         expect(subject.render).to include('describe "GET" do')
       end


### PR DESCRIPTION
This PR addresses issue #54. It causes Rambo-generated tests to create output files with each of the response bodies received, enabling easy manual comparison in the event of failures. For more details see #54. 