### PR TITLE
Add --no-rails flag

### DIFF
--- a/bin/rambo
+++ b/bin/rambo
@@ -9,11 +9,12 @@ require "optparse"
 
 filename = ARGV[0] ? File.expand_path(ARGV[0], FileUtils.pwd) : nil
 
-options = { rails: true }
+options = {}
 
 OptionParser.new do |opts|
   opts.banner = "Usage: rambo [FILE] [OPTIONS]"
 
+  options[:rails] = true
   opts.on("--no-rails", "Generate tests for a non-Rails API") do |v|
     options[:rails] = false
   end

--- a/bin/rambo
+++ b/bin/rambo
@@ -5,7 +5,18 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "fileutils"
 require "cli"
+require "optparse"
 
 filename = ARGV[0] ? File.expand_path(ARGV[0], FileUtils.pwd) : nil
 
-Rambo::CLI.new(filename, STDOUT).run!
+options = { rails: true }
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: rambo [FILE] [OPTIONS]"
+
+  opts.on("--no-rails", "Generate tests for a non-Rails API") do |v|
+    options[:rails] = false
+  end
+end.parse!
+
+Rambo::CLI.new(filename, options, STDOUT).run!

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -7,11 +7,11 @@ module Rambo
       @stdout  = stdout
       @stderr  = stderr
       @file    = raml_file
-      @options = options
+      @options = opts
 
       validate!
 
-      @generator = Rambo::DocumentGenerator.new(file)
+      @generator = Rambo::DocumentGenerator.new(file, options)
     end
 
     def run!

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -4,9 +4,10 @@ require "document_generator"
 module Rambo
   class CLI
     def initialize(raml_file=nil, opts={}, stdout=STDOUT, stderr=STDERR)
-      @stdout = stdout
-      @stderr = stderr
-      @file   = raml_file
+      @stdout  = stdout
+      @stderr  = stderr
+      @file    = raml_file
+      @options = options
 
       validate!
 
@@ -40,7 +41,7 @@ module Rambo
 
     private
 
-    attr_accessor :file, :stdout, :stderr, :generator
+    attr_accessor :file, :stdout, :stderr, :generator, :options
 
     def print_logo
       stdout.puts logo.colorize(color: String.colors.sample)

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -3,7 +3,7 @@ require "document_generator"
 
 module Rambo
   class CLI
-    def initialize(raml_file=nil, stdout=STDOUT, stderr=STDERR)
+    def initialize(raml_file=nil, opts={}, stdout=STDOUT, stderr=STDERR)
       @stdout = stdout
       @stderr = stderr
       @file   = raml_file

--- a/lib/document_generator.rb
+++ b/lib/document_generator.rb
@@ -6,7 +6,7 @@ require "rspec/helper_file"
 
 module Rambo
   class DocumentGenerator
-    attr_accessor :file, :raml
+    attr_accessor :file, :raml, :options
 
     def initialize(file, options={})
       @file    = file
@@ -24,7 +24,7 @@ module Rambo
 
     def generate_spec_file!
       spec_file_name = file.match(/[^\/]*\.raml$/).to_s.gsub(/\.raml$/, "_spec.rb")
-      contents       = Rambo::RSpec::SpecFile.new(raml).render
+      contents       = Rambo::RSpec::SpecFile.new(raml, options).render
       File.write("spec/contract/#{spec_file_name}", contents)
     end
 

--- a/lib/document_generator.rb
+++ b/lib/document_generator.rb
@@ -8,9 +8,10 @@ module Rambo
   class DocumentGenerator
     attr_accessor :file, :raml
 
-    def initialize(file)
-      @file = file
-      @raml = Raml::Parser.parse_file(file)
+    def initialize(file, options={})
+      @file    = file
+      @raml    = Raml::Parser.parse_file(file)
+      @options = options
     end
 
     def generate_spec_dir!

--- a/lib/rspec/example_group.rb
+++ b/lib/rspec/example_group.rb
@@ -6,8 +6,9 @@ module Rambo
 
       attr_reader :resource
 
-      def initialize(resource)
+      def initialize(resource, options={})
         @resource = resource
+        @options  = options
       end
 
       def template

--- a/lib/rspec/examples.rb
+++ b/lib/rspec/examples.rb
@@ -3,10 +3,11 @@ require "rspec/example_group"
 module Rambo
   module RSpec
     class Examples
-      attr_reader :raml, :resources, :examples
+      attr_reader :raml, :resources, :examples, :options
 
-      def initialize(raml)
-        @raml = raml
+      def initialize(raml, options={})
+        @raml    = raml
+        @options = options
       end
 
       def compose
@@ -20,7 +21,7 @@ module Rambo
       end
 
       def example_groups
-        @example_groups ||= resources.map {|r| ExampleGroup.new(r) }
+        @example_groups ||= resources.map {|r| ExampleGroup.new(r, options) }
       end
 
       def generate!

--- a/lib/rspec/spec_file.rb
+++ b/lib/rspec/spec_file.rb
@@ -7,14 +7,14 @@ require "raml_models"
 module Rambo
   module RSpec
     class SpecFile
-      attr_reader :raml, :examples
+      attr_reader :raml, :examples, :options
 
       TEMPLATE_PATH = File.expand_path('../templates/spec_file_template.erb', __FILE__)
 
       def initialize(raml, options={})
         @raml     = Rambo::RamlModels::Api.new(raml)
-        @examples = Examples.new(@raml)
         @options  = options
+        @examples = Examples.new(@raml, @options)
       end
 
       def template

--- a/lib/rspec/spec_file.rb
+++ b/lib/rspec/spec_file.rb
@@ -11,9 +11,10 @@ module Rambo
 
       TEMPLATE_PATH = File.expand_path('../templates/spec_file_template.erb', __FILE__)
 
-      def initialize(raml)
+      def initialize(raml, options={})
         @raml     = Rambo::RamlModels::Api.new(raml)
         @examples = Examples.new(@raml)
+        @options  = options
       end
 
       def template

--- a/lib/rspec/templates/example_group_template.erb
+++ b/lib/rspec/templates/example_group_template.erb
@@ -22,18 +22,18 @@
       let(:output_file) do
         "<%= "spec/contract/output/#{@resource.to_s.gsub("/", "")}_#{method.method}_response.json" %>"
       end
-
+      <% resp_method = @options[:rails] ? "response" : "last_response" %>
       it "<%= method.description && method.description.downcase || "#{method.method}s the resource" %>" do
         <%= method.method %> route<% if method.request_body %>, request_body<% end %><% if method.headers %>, headers<% end %>
 
-        File.open(output_file, "w+") {|file| file.puts JSON.pretty_generate(JSON.parse(response.body)) }
+        File.open(output_file, "w+") {|file| file.puts JSON.pretty_generate(JSON.parse(<%= resp_method %>.body)) }
 
-        expect(response.body).to <%= has_schema ? "match_schema response_schema" : "eql response_body" %>
+        expect(<%= resp_method %>.body).to <%= has_schema ? "match_schema response_schema" : "eql response_body" %>
       end
 
       it "returns status <%= method.responses.first.status_code %>" do
         <%= method.method %> route<% if method.request_body %>, request_body<% end %><% if method.headers %>, headers<% end %>
-        expect(response.status).to eql <%= method.responses.first.status_code %>
+        expect(<%= resp_method %>.status).to eql <%= method.responses.first.status_code %>
       end
     end<%- end %>
   end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Rambo::CLI do
-  let(:io) { StringIO.new }
-  let(:stderr) { StringIO.new }
-  let(:opts) { { rails: true } }
+  let(:io)         { StringIO.new }
+  let(:stderr)     { StringIO.new }
+  let(:opts)       { { rails: true } }
   let(:valid_file) { File.expand_path('../../support/foobar.raml', __FILE__) }
 
   describe "run!" do

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -1,9 +1,11 @@
 RSpec.describe Rambo::CLI do
   let(:io) { StringIO.new }
+  let(:stderr) { StringIO.new }
+  let(:opts) { { rails: true } }
   let(:valid_file) { File.expand_path('../../support/foobar.raml', __FILE__) }
 
   describe "run!" do
-    let(:cli) { Rambo::CLI.new(valid_file, io, STDERR) }
+    let(:cli) { Rambo::CLI.new(valid_file, opts, io, stderr) }
 
     before(:each) do
       allow_any_instance_of(Rambo::DocumentGenerator).to receive(:generate_rambo_helper!)

--- a/spec/lib/document_generator_spec.rb
+++ b/spec/lib/document_generator_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Rambo::DocumentGenerator do
   let(:valid_file) { File.expand_path('../../support/foobar.raml', __FILE__) }
-  let(:generator) { Rambo::DocumentGenerator.new(valid_file) }
+  let(:options) { { rails: true } }
+  let(:generator) { Rambo::DocumentGenerator.new(valid_file, options) }
 
   before(:each) do
     allow_any_instance_of(Rambo::DocumentGenerator).to receive(:extract_raml)

--- a/spec/lib/rspec/example_group_spec.rb
+++ b/spec/lib/rspec/example_group_spec.rb
@@ -69,5 +69,19 @@ RSpec.describe Rambo::RSpec::ExampleGroup do
         expect(subject.render).to include("let(:headers) do")
       end
     end
+
+    context "Rails app" do
+      it "uses response" do
+        expect(subject.render).to include("expect(response.body)")
+      end
+    end
+
+    context "non-Rails app" do
+      let(:options) { { rails: false } }
+
+      it "uses last_response" do
+        expect(subject.render).to include("expect(last_response.body)")
+      end
+    end
   end
 end

--- a/spec/lib/rspec/example_group_spec.rb
+++ b/spec/lib/rspec/example_group_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Rambo::RSpec::ExampleGroup do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
   let(:raml)      { Raml::Parser.parse_file(raml_file) }
   let(:resource)  { Rambo::RamlModels::Resource.new(raml.resources.first) }
-
-  subject         { Rambo::RSpec::ExampleGroup.new(resource) }
+  let(:options)   { { rails: true } }
+  subject         { Rambo::RSpec::ExampleGroup.new(resource, options) }
 
   before(:each) do
     FileUtils.mkdir_p(File.expand_path("spec/support/examples"))

--- a/spec/lib/rspec/examples_spec.rb
+++ b/spec/lib/rspec/examples_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe Rambo::RSpec::Examples do
   let(:raml_file) { File.expand_path("../../../support/foobar.raml", __FILE__) }
   let(:raw_raml)  { Raml::Parser.parse_file(raml_file) }
+  let(:options)   { { rails: true } }
   let(:raml)      { Rambo::RamlModels::Api.new(raw_raml) }
 
-  subject { Rambo::RSpec::Examples.new(raml) }
+  subject { Rambo::RSpec::Examples.new(raml, options) }
 
   before(:each) do
     FileUtils.mkdir_p(File.expand_path("spec/support/examples"))

--- a/spec/lib/rspec/spec_file_spec.rb
+++ b/spec/lib/rspec/spec_file_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Rambo::RSpec::SpecFile do
   let(:raw_raml)  { Raml::Parser.parse_file(raml_file) }
+  let(:options)   { { rails: true } }
   let(:raml)      { Rambo::RamlModels::Api.new(raw_raml) }
-  let(:spec_file) { Rambo::RSpec::SpecFile.new(raw_raml) }
+  let(:spec_file) { Rambo::RSpec::SpecFile.new(raw_raml, options) }
 
   before(:each) do
     FileUtils.mkdir_p(File.expand_path("spec/support/examples"))


### PR DESCRIPTION
This PR adds the `--no-rails` flag, enabling tests to be generated for non-Rails apps. This addresses one of the implementation ideas for #62.