### PR TITLE
Update json_test_data and increment version for bugfix

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,7 +1,7 @@
 module Rambo
   MAJOR = '0'
   MINOR = '2'
-  PATCH = '1'
+  PATCH = '2'
 
   def self.version
     [Rambo::MAJOR, Rambo::MINOR, Rambo::PATCH].join('.')

--- a/rambo_ruby.gemspec
+++ b/rambo_ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rspec", "~> 3.4"
   s.add_dependency "raml-rb", "~> 0.0.6"
   s.add_dependency "colorize", "~> 0.7"
-  s.add_dependency "json_test_data", "~> 1.1", ">= 1.1.1"
+  s.add_dependency "json_test_data", "~> 1.1", ">= 1.1.2"
   s.add_dependency "json-schema", "~> 2.6"
   s.add_dependency "rake", "~> 11.0"
   s.add_dependency "activesupport", "~> 4.0"


### PR DESCRIPTION
This PR updates to the latest version of JSON Test Data, which fixes a bug causing errors when a user attempted to generate a string in "date-time" format.