### PR TITLE
Fix for Rails bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Rambo is a gem that generates API contract tests from API docs in [RAML](http://raml.org/). Rambo is being developed to test APIs complying with standard REST practices. Mileage may vary with other architectures, but I'm happy to consider pull requests.
 
-#### The current version of Rambo is 0.2.3. It is highly unstable and has a limited feature set. Use at your own risk and please file issue reports if they come up!
+#### The current version of Rambo is 0.3.1. It is highly unstable and has a limited feature set. Use at your own risk and please file issue reports if they come up!
 
 ## Usage
 You can install Rambo using:
@@ -14,7 +14,7 @@ gem install rambo_ruby
 You can also add it to your project's Gemfile:
 ```ruby
 group :development, :test do
-  gem 'rambo_ruby', '~> 0.3.0'
+  gem 'rambo_ruby', '~> 0.3.1'
 end
 ```
 There are three options for generating tests from Rambo: The command line tool, the rake task, and the Ruby API. In all cases, Rambo will look for a `.rambo.yml` file in the root directory of your project for configuration options. Options may also be passed in through the command line as arguments or the Ruby API as a hash. There is currently no option to pass arguments to the Rake task, but Rambo comes pre-loaded with sensible defaults, and the `.rambo.yml` file is always an option.
@@ -93,7 +93,7 @@ In the present version, Rambo only generates tests from a single RAML file. If y
 As noted above, Rambo currently supports only Rack-based apps. Since Rails is the most popular Ruby framework, it assumes your app is a Rails app unless specified otherwise. Since Rack::Test syntax differs when testing Rails and non-Rails apps, you will need to tell Rambo if your app is not a Rails app using the `--no-rails` switch on the command line, the `{ rails: false }` option hash for the Ruby API, or specifying `rails: false` in your `.rambo.yml` file.
 
 ## About the Project
-I started Rambo in March of 2016 as part of my work at [Renew Financial](http://renewfinancial.com). For this reason, our primary focus has been on adding the features and functionality that are most important for testing RF's back-end services. Since I am no longer employed by Renew Financial, I now have more latitude to do with the project what I want, but also less time to do it.
+I started Rambo in March of 2016 as part of my work at [Renew Financial](http://renewfinancial.com). For this reason, our primary focus has been on adding the features and functionality that are most important for testing RF's back-end services. Since my contract with Renew Financial has ended, I now have more latitude to do with the project what I want, but also less time to do it.
 
 Rambo, therefore, considers RAML 1.0 and Rails 4 the default, and support for other frameworks and for RAML 0.8 is currently lower priority. We would be delighted to merge pull requests adding such support, as long as they don't adversely affect the features we need most.
 

--- a/lib/rambo/document_generator.rb
+++ b/lib/rambo/document_generator.rb
@@ -15,7 +15,7 @@ module Rambo
         generator.generate_matcher_dir!
         generator.generate_examples!
         generator.generate_spec_file!
-        generator.generate_rambo_helper!
+        generator.generate_rambo_helper!(options)
         generator.generate_matchers!
       end
     end
@@ -43,7 +43,9 @@ module Rambo
     def generate_rambo_helper!
       Rambo::RSpec::HelperFile.new(
         template_path: File.expand_path("../rspec/templates/rambo_helper_file_template.erb", __FILE__),
-        file_path: "spec/rambo_helper.rb"
+        file_path:     "spec/rambo_helper.rb",
+        raml:          raml,
+        options:       options
       ).generate
     end
 
@@ -54,7 +56,7 @@ module Rambo
     def generate_matchers!
       Rambo::RSpec::HelperFile.new(
         template_path: File.expand_path("../rspec/templates/matcher_file_template.erb", __FILE__),
-        file_path: "spec/support/matchers/rambo_matchers.rb"
+        file_path: "spec/support/matchers/rambo_matchers.rb", raml: nil
       ).generate
     end
   end

--- a/lib/rambo/rspec/templates/rambo_helper_file_template.erb
+++ b/lib/rambo/rspec/templates/rambo_helper_file_template.erb
@@ -1,3 +1,15 @@
-require "spec_helper"
-
+require "<%= @options.fetch(:rails, nil) ? "rails_helper" : "spec_helper" %>"
+require "rack/test"
 require_relative "./support/matchers/rambo_matchers"
+
+<% if options.fetch(:rails, nil) %>module ApiHelper
+  include Rack::Test::Methods
+
+  def app
+    Rails.application
+  end
+end
+
+RSpec.configure do |config|
+  config.include ApiHelper, type: :request
+end<% end %>

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,7 +1,7 @@
 module Rambo
   MAJOR = '0'
   MINOR = '3'
-  PATCH = '0'
+  PATCH = '1'
 
   def self.version
     [Rambo::MAJOR, Rambo::MINOR, Rambo::PATCH].join('.')

--- a/spec/lib/rambo/document_generator_spec.rb
+++ b/spec/lib/rambo/document_generator_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Rambo::DocumentGenerator do
   let(:valid_file) { File.join(SPEC_DIR_ROOT, "support/foobar.raml") }
-  let(:options) { { rails: true } }
-  let(:generator) { Rambo::DocumentGenerator.new(valid_file, options) }
+  let(:options)    { { rails: true } }
+  
+  subject          { described_class.new(valid_file, options) }
 
   before(:each) do
     allow_any_instance_of(Rambo::DocumentGenerator).to receive(:extract_raml)
@@ -51,23 +52,25 @@ RSpec.describe Rambo::DocumentGenerator do
   describe "#generate_spec_dir!" do
     it "generates the spec/contract directory" do
       expect(FileUtils).to receive(:mkdir_p).with("spec/contract/output")
-      generator.generate_spec_dir!
+      subject.generate_spec_dir!
     end
   end
 
   describe "#generate_rambo_helper!" do
+
     it "generates the rambo_helper file" do
       aggregate_failures do
         expect_any_instance_of(Rambo::RSpec::HelperFile)
           .to receive(:initialize)
-          .with({
+          .with(hash_including(
             :template_path => File.join(RAMBO_ROOT, "rambo/rspec/templates/rambo_helper_file_template.erb"),
-            :file_path     => "spec/rambo_helper.rb"
-          })
+            :file_path     => "spec/rambo_helper.rb",
+            :options       => { rails: true }
+          ))
         expect_any_instance_of(Rambo::RSpec::HelperFile).to receive(:generate)
       end
 
-      generator.generate_rambo_helper!
+      subject.generate_rambo_helper!
     end
   end
 
@@ -79,14 +82,14 @@ RSpec.describe Rambo::DocumentGenerator do
     it "generates foobar_spec.rb" do
       allow_any_instance_of(Rambo::RSpec::SpecFile).to receive(:render).and_return("foo")
       expect(File).to receive(:write).with("spec/contract/foobar_spec.rb", "foo")
-      generator.generate_spec_file!
+      subject.generate_spec_file!
     end
   end
 
   describe "#generate_matcher_dir!" do
     it "creates a spec/support/matchers directory" do
       expect(FileUtils).to receive(:mkdir_p).with("spec/support/matchers")
-      generator.generate_matcher_dir!
+      subject.generate_matcher_dir!
     end
   end
 
@@ -95,21 +98,21 @@ RSpec.describe Rambo::DocumentGenerator do
       aggregate_failures do
         expect_any_instance_of(Rambo::RSpec::HelperFile)
           .to receive(:initialize)
-          .with(
-            template_path: File.join(RAMBO_ROOT, "rambo/rspec/templates/matcher_file_template.erb"),
-            file_path: "spec/support/matchers/rambo_matchers.rb"
-          )
+          .with(hash_including(
+            :template_path => File.join(RAMBO_ROOT, "rambo/rspec/templates/matcher_file_template.erb"),
+            :file_path     => "spec/support/matchers/rambo_matchers.rb"
+          ))
         expect_any_instance_of(Rambo::RSpec::HelperFile).to receive(:generate)
       end
 
-      generator.generate_matchers!
+      subject.generate_matchers!
     end
   end
 
   describe "#generate_examples!" do
     it "creates the directory" do
       expect(FileUtils).to receive(:mkdir_p).with("spec/support/examples")
-      generator.generate_examples!
+      subject.generate_examples!
     end
   end
 end


### PR DESCRIPTION
This PR causes the `rambo_helper.rb` file to configure RSpec with Rack::Test when the `:rails` option is set to `true`. Resolves #75.