### PR TITLE
Allow ActiveSupport >= 4.0

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,7 +1,7 @@
 module Rambo
   MAJOR = '0'
   MINOR = '3'
-  PATCH = '1'
+  PATCH = '2'
 
   def self.version
     [Rambo::MAJOR, Rambo::MINOR, Rambo::PATCH].join('.')

--- a/rambo_ruby.gemspec
+++ b/rambo_ruby.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.add_dependency "json_test_data", "~> 1.1", ">= 1.1.3"
   s.add_dependency "json-schema", "~> 2.6"
   s.add_dependency "rake", "~> 11.0"
-  s.add_dependency "activesupport", ">= 4.0"
+
+  if RUBY_VERSION < "2.2.2"
+    s.add_dependency "activesupport", "~> 4.0"
+  else
+    s.add_dependency "activesupport", ">= 4.0"
+  end
 
   s.add_development_dependency "cucumber", "~> 2.1"
   s.add_development_dependency "json", "~> 1.7"

--- a/rambo_ruby.gemspec
+++ b/rambo_ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json_test_data", "~> 1.1", ">= 1.1.3"
   s.add_dependency "json-schema", "~> 2.6"
   s.add_dependency "rake", "~> 11.0"
-  s.add_dependency "activesupport", "~> 4.0"
+  s.add_dependency "activesupport", ">= 4.0"
 
   s.add_development_dependency "cucumber", "~> 2.1"
   s.add_development_dependency "json", "~> 1.7"


### PR DESCRIPTION
This PR updates dependencies to allow any ActiveSupport version >= 4.0. This enables Rambo to work with Rails 5.