### PR TITLE
Support Rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Rambo is a gem that generates API contract tests from API docs in [RAML](http://raml.org/). Rambo is being developed to test APIs complying with standard REST practices. Mileage may vary with other architectures, but I'm happy to consider pull requests.
 
-#### The current version of Rambo is 0.3.3. It is highly unstable and has a limited feature set. Use at your own risk and please file issue reports if they come up!
+#### The current version of Rambo is 0.4.0. It is highly unstable and has a limited feature set. Use at your own risk and please file issue reports if they come up!
 
 ## Usage
 You can install Rambo using:
@@ -14,7 +14,7 @@ gem install rambo_ruby
 You can also add it to your project's Gemfile:
 ```ruby
 group :development, :test do
-  gem 'rambo_ruby', '~> 0.3.3'
+  gem 'rambo_ruby', '~> 0.4'
 end
 ```
 There are three options for generating tests from Rambo: The command line tool, the rake task, and the Ruby API. In all cases, Rambo will look for a `.rambo.yml` file in the root directory of your project for configuration options. Options may also be passed in through the command line as arguments or the Ruby API as a hash. There is currently no option to pass arguments to the Rake task, but Rambo comes pre-loaded with sensible defaults, and the `.rambo.yml` file is always an option.

--- a/lib/rambo/rspec/templates/example_group_template.erb
+++ b/lib/rambo/rspec/templates/example_group_template.erb
@@ -7,7 +7,6 @@
         <%= headers.join(",\n        ") %>
         }
       end<% end %><% if method.request_body %>
-
       let(:request_body) do
         File.read("<%= "spec/support/examples/#{@resource.to_s.gsub("/", "")}_#{method.method}_request_body.json" %>")
       end<% end %><% if has_schema = method.responses.first.bodies.first.schema %>
@@ -22,18 +21,18 @@
       let(:output_file) do
         "<%= "spec/contract/output/#{@resource.to_s.gsub("/", "")}_#{method.method}_response.json" %>"
       end
-      <% resp_method = @options[:rails] ? "response" : "last_response" %>
+
       it "<%= method.description && method.description.downcase || "#{method.method}s the resource" %>" do
         <%= method.method %> route<% if method.request_body %>, request_body<% end %><% if method.headers %>, headers<% end %>
 
-        File.open(output_file, "w+") {|file| file.puts JSON.pretty_generate(JSON.parse(<%= resp_method %>.body)) }
+        File.open(output_file, "w+") {|file| file.puts JSON.pretty_generate(JSON.parse(last_response.body)) }
 
-        expect(<%= resp_method %>.body).to <%= has_schema ? "match_schema response_schema" : "eql response_body" %>
+        expect(last_response.body).to <%= has_schema ? "match_schema response_schema" : "eql response_body" %>
       end
 
       it "returns status <%= method.responses.first.status_code %>" do
         <%= method.method %> route<% if method.request_body %>, request_body<% end %><% if method.headers %>, headers<% end %>
-        expect(<%= resp_method %>.status).to eql <%= method.responses.first.status_code %>
+        expect(last_response.status).to eql <%= method.responses.first.status_code %>
       end
     end<%- end %>
   end

--- a/lib/rambo/rspec/templates/rambo_helper_file_template.erb
+++ b/lib/rambo/rspec/templates/rambo_helper_file_template.erb
@@ -11,5 +11,5 @@ require_relative "./support/matchers/rambo_matchers"
 end
 
 RSpec.configure do |config|
-  config.include ApiHelper, type: :request
+  config.include ApiHelper, type: :rambo
 end<% end %>

--- a/lib/rambo/rspec/templates/spec_file_template.erb
+++ b/lib/rambo/rspec/templates/spec_file_template.erb
@@ -1,6 +1,6 @@
 require "rambo_helper"
 
-RSpec.describe "<%= @raml.title %>", type: :request do
+RSpec.describe "<%= @raml.title %>", type: :rambo do
 
   # Delete output files from previous test run prior to running tests again
   before(:all) do

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,7 +1,7 @@
 module Rambo
   MAJOR = '0'
-  MINOR = '3'
-  PATCH = '3'
+  MINOR = '4'
+  PATCH = '0'
 
   def self.version
     [Rambo::MAJOR, Rambo::MINOR, Rambo::PATCH].join('.')

--- a/spec/lib/rambo/rspec/example_group_spec.rb
+++ b/spec/lib/rambo/rspec/example_group_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Rambo::RSpec::ExampleGroup do
       it "creates a response schema object" do
         aggregate_failures do
           expect(subject.render).to include("let(:response_schema) do")
-          expect(subject.render).to include("expect(response.body).to match_schema response_schema")
+          expect(subject.render).to include("expect(last_response.body).to match_schema response_schema")
         end
       end
     end
@@ -45,7 +45,7 @@ RSpec.describe Rambo::RSpec::ExampleGroup do
       it "creates a response_body object" do
         aggregate_failures do
           expect(subject.render).to include("let(:response_body) do")
-          expect(subject.render).to include("expect(response.body).to eql response_body")
+          expect(subject.render).to include("expect(last_response.body).to eql response_body")
         end
       end
     end
@@ -67,20 +67,6 @@ RSpec.describe Rambo::RSpec::ExampleGroup do
 
       it "adds headers" do
         expect(subject.render).to include("let(:headers) do")
-      end
-    end
-
-    context "Rails app" do
-      it "uses response" do
-        expect(subject.render).to include("expect(response.body)")
-      end
-    end
-
-    context "non-Rails app" do
-      let(:options) { { rails: false } }
-
-      it "uses last_response" do
-        expect(subject.render).to include("expect(last_response.body)")
       end
     end
   end


### PR DESCRIPTION
This PR changes the Rails Rack::Test syntax to match the non-Rails syntax. This will need to be regression-tested against Rails 4.