### PR TITLE
Use PORO instead of JSON object in specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Rambo is a gem that generates API contract tests from API docs in [RAML](http://raml.org/). Rambo is being developed to test APIs complying with standard REST practices. Mileage may vary with other architectures, but I'm happy to consider pull requests.
 
-#### The current version of Rambo is 0.4.0. It is highly unstable and has a limited feature set. Use at your own risk and please file issue reports if they come up!
+#### The current version of Rambo is 0.5.0. It is highly unstable and has a limited feature set. Use at your own risk and please file issue reports if they come up!
 
 ## Usage
 You can install Rambo using:
@@ -14,7 +14,7 @@ gem install rambo_ruby
 You can also add it to your project's Gemfile:
 ```ruby
 group :development, :test do
-  gem 'rambo_ruby', '~> 0.4'
+  gem 'rambo_ruby', '~> 0.5'
 end
 ```
 There are three options for generating tests from Rambo: The command line tool, the rake task, and the Ruby API. In all cases, Rambo will look for a `.rambo.yml` file in the root directory of your project for configuration options. Options may also be passed in through the command line as arguments or the Ruby API as a hash. There is currently no option to pass arguments to the Rake task, but Rambo comes pre-loaded with sensible defaults, and the `.rambo.yml` file is always an option.

--- a/lib/rambo/rspec/templates/example_group_template.erb
+++ b/lib/rambo/rspec/templates/example_group_template.erb
@@ -8,7 +8,10 @@
         }
       end<% end %><% if method.request_body %>
       let(:request_body) do
-        File.read("<%= "spec/support/examples/#{@resource.to_s.gsub("/", "")}_#{method.method}_request_body.json" %>")
+        JSON.parse(
+          File.read("<%= "spec/support/examples/#{@resource.to_s.gsub("/", "")}_#{method.method}_request_body.json" %>"),
+          symbolize_names: true
+        )
       end<% end %><% if has_schema = method.responses.first.bodies.first.schema %>
 
       let(:response_schema) do

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,6 +1,6 @@
 module Rambo
   MAJOR = '0'
-  MINOR = '4'
+  MINOR = '5'
   PATCH = '0'
 
   def self.version


### PR DESCRIPTION
This PR ensures Rack::Test passes a PORO instead of a JSON object into the API call. This resolves some issues we were having with Rails 4 and 5 apps but will break APIs that depend on a JSON object being passed into Rack::Test.