### PR TITLE
Change option structure

### DIFF
--- a/bin/rambo
+++ b/bin/rambo
@@ -15,7 +15,7 @@ OptionParser.new do |opts|
   opts.banner = "Usage: rambo [FILE] [OPTIONS]"
 
   options[:framework] = :rails
-  opts.on("--framework", "Choose rails (default), sinatra:classic, sinatra:modular, or grape") do |v|
+  opts.on("--framework=FRAMEWORK", "Choose rails (default), sinatra:classic, sinatra:modular, or grape") do |v|
     options[:framework] = v.to_sym
   end
   opts.on("--token=TOKEN", "-T=TOKEN", "Specify an API token") do |v|

--- a/bin/rambo
+++ b/bin/rambo
@@ -14,9 +14,9 @@ options = {}
 OptionParser.new do |opts|
   opts.banner = "Usage: rambo [FILE] [OPTIONS]"
 
-  options[:rails] = true
-  opts.on("--no-rails", "Generate tests for a non-Rails API") do |v|
-    options[:rails] = false
+  options[:framework] = :rails
+  opts.on("--framework", "Choose rails (default), sinatra:classic, sinatra:modular, or grape") do |v|
+    options[:framework] = v.to_sym
   end
   opts.on("--token=TOKEN", "-T=TOKEN", "Specify an API token") do |v|
     options[:token] = v

--- a/lib/rambo.rb
+++ b/lib/rambo.rb
@@ -8,9 +8,9 @@ module Rambo
     attr_reader :options, :file
 
     def generate_contract_tests!(file: nil, options: {})
-      @options         = yaml_options.merge(options)
-      @options[:rails] = true unless @options.fetch(:rails, nil) == false
-      @file            = file || @options.delete(:raml) || raml_file
+      @options             = yaml_options.merge(options)
+      @options[:framework] = :rails if @options.fetch(:framework, nil).nil?
+      @file                = file || @options.delete(:raml) || raml_file
 
       DocumentGenerator.generate!(@file, @options)
     end
@@ -20,13 +20,15 @@ module Rambo
     def yaml_options
       opts = YAML.load(File.read(File.join(FileUtils.pwd, ".rambo.yml"))).symbolize_keys
 
+      opts[:framework] = opts[:framework].to_sym if opts[:framework]
+
       if opts && opts.fetch(:raml, nil)
         opts[:raml] = File.join(FileUtils.pwd, opts.fetch(:raml))
       end
 
       opts || {}
     rescue
-      { rails: true }
+      { framework: :rails }
     end
 
     # TODO: Permit use of multiple RAML files, since right now this only takes

--- a/lib/rambo/rspec/example_group.rb
+++ b/lib/rambo/rspec/example_group.rb
@@ -8,7 +8,7 @@ module Rambo
 
       def initialize(resource, options={})
         @resource = resource
-        @options  = options || { rails: true }
+        @options  = options || { framework: :rails }
       end
 
       def template

--- a/lib/rambo/rspec/helper_file.rb
+++ b/lib/rambo/rspec/helper_file.rb
@@ -11,8 +11,17 @@ module Rambo
       def initialize(template_path:, file_path:, raml: nil, options: nil)
         @template_path = template_path
         @file_path     = file_path
-        @options       = options || { rails: true }
+        @options       = options || { framework: :rails }
         @raml          = raml ? Rambo::RamlModels::Api.new(raml) : nil
+      end
+
+      def app_classes
+        {
+          :rails             => "Rails.application",
+          :"sinatra:classic" => "Sinatra::Application",
+          :"sinatra:modular" => "Sinatra::Base.descendants.find {|klass| klass != Sinatra::Application } || Sinatra::Application",
+          :grape             => "Grape::API.descendants.first"
+        }
       end
 
       def generate

--- a/lib/rambo/rspec/templates/example_group_template.erb
+++ b/lib/rambo/rspec/templates/example_group_template.erb
@@ -1,4 +1,4 @@
-  describe "<%= @resource.to_s %>" do
+<% rails = @options.fetch(:framework, :rails) == :rails %>  describe "<%= @resource.to_s %>" do
     let(:route) { "<%= @resource.to_s %>" }
     <%- @resource.http_methods.each do |method| %>
     describe "<%= method.method.upcase %>" do
@@ -6,12 +6,13 @@
         {
         <%= headers.join(",\n        ") %>
         }
-      end<% end %><% if method.request_body %>
+      end<% end %>
+      <% if method.request_body %>
       let(:request_body) do
-        JSON.parse(
+        <% if rails %>JSON.parse(
           File.read("<%= "spec/support/examples/#{@resource.to_s.gsub("/", "")}_#{method.method}_request_body.json" %>"),
           symbolize_names: true
-        )
+        )<% else %>File.read("<%= "spec/support/examples/#{@resource.to_s.gsub("/", "")}_#{method.method}_request_body.json" %>")<% end %>
       end<% end %><% if has_schema = method.responses.first.bodies.first.schema %>
 
       let(:response_schema) do

--- a/lib/rambo/rspec/templates/rambo_helper_file_template.erb
+++ b/lib/rambo/rspec/templates/rambo_helper_file_template.erb
@@ -1,15 +1,16 @@
-require "<%= @options.fetch(:rails, nil) ? "rails_helper" : "spec_helper" %>"
+require "<%= @options.fetch(:framework, :rails) ? "rails_helper" : "spec_helper" %>"
 require "rack/test"
 require_relative "./support/matchers/rambo_matchers"
 
-<% if options.fetch(:rails, nil) %>module ApiHelper
+module ApiHelper
   include Rack::Test::Methods
 
   def app
-    Rails.application
+    require "active_support/core_ext/class/subclasses"
+    <%= app_classes.fetch(@options.fetch(:framework, :rails)) %>
   end
 end
 
 RSpec.configure do |config|
   config.include ApiHelper, type: :rambo
-end<% end %>
+end

--- a/lib/rambo/rspec/templates/rambo_helper_file_template.erb
+++ b/lib/rambo/rspec/templates/rambo_helper_file_template.erb
@@ -1,4 +1,4 @@
-require "<%= @options.fetch(:framework, :rails) ? "rails_helper" : "spec_helper" %>"
+require "<%= @options.fetch(:framework, nil).nil? || @options.fetch(:framework) == :rails ? "rails_helper" : "spec_helper" %>"
 require "rack/test"
 require_relative "./support/matchers/rambo_matchers"
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,6 +1,6 @@
 module Rambo
   MAJOR = '0'
-  MINOR = '5'
+  MINOR = '6'
   PATCH = '0'
 
   def self.version

--- a/spec/lib/rambo/cli_spec.rb
+++ b/spec/lib/rambo/cli_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Rambo::CLI do
   let(:io)         { StringIO.new }
   let(:stderr)     { StringIO.new }
-  let(:opts)       { { rails: true } }
+  let(:opts)       { { framework: :rails } }
   let(:valid_file) { File.join(SPEC_DIR_ROOT, 'support/foobar.raml',) }
 
   describe "run!" do

--- a/spec/lib/rambo/document_generator_spec.rb
+++ b/spec/lib/rambo/document_generator_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rambo::DocumentGenerator do
   let(:valid_file) { File.join(SPEC_DIR_ROOT, "support/foobar.raml") }
-  let(:options)    { { rails: true } }
+  let(:options)    { { framework: :rails } }
   
   subject          { described_class.new(valid_file, options) }
 
@@ -65,7 +65,7 @@ RSpec.describe Rambo::DocumentGenerator do
           .with(hash_including(
             :template_path => File.join(RAMBO_ROOT, "rambo/rspec/templates/rambo_helper_file_template.erb"),
             :file_path     => "spec/rambo_helper.rb",
-            :options       => { rails: true }
+            :options       => { framework: :rails }
           ))
         expect_any_instance_of(Rambo::RSpec::HelperFile).to receive(:generate)
       end

--- a/spec/lib/rambo_spec.rb
+++ b/spec/lib/rambo_spec.rb
@@ -2,13 +2,13 @@ RSpec.describe Rambo do
   let(:file_contents) do
     <<-EOF
 raml: doc/raml/foobar.raml
-rails: false
+framework: rails
     EOF
   end
 
   describe ".generate_contract_tests!" do
     let(:valid_file)      { "foobar.raml" }
-    let(:default_options) { { rails: true } }
+    let(:default_options) { { framework: :rails } }
 
     before(:each) do
       allow(Dir).to receive(:foreach).and_return("/Users/dscheider/rambo/doc/raml/#{valid_file}")
@@ -39,37 +39,57 @@ rails: false
       it "sets the RAML file to the one from the file" do
         expect(Rambo::DocumentGenerator)
           .to receive(:generate!)
-          .with(File.expand_path("doc/raml/foobar.raml"), { rails: false })
+          .with(File.expand_path("doc/raml/foobar.raml"), { framework: :rails })
 
         Rambo.generate_contract_tests!
       end
 
-      context "rails option set to false in file" do
-        it "sets rails option to false" do
-          allow(Rambo).to receive(:yaml_options).and_return({ rails: false })
+      context "framework set to sinatra:classic" do
+        it "sets framework to sinatra:classic" do
+          allow(Rambo).to receive(:yaml_options).and_return({ framework: :"sinatra:classic" })
           expect(Rambo::DocumentGenerator)
             .to receive(:generate!)
-            .with("/Users/dscheider/rambo/doc/raml/#{valid_file}", { rails: false })
+            .with("/Users/dscheider/rambo/doc/raml/#{valid_file}", { framework: :"sinatra:classic" })
           Rambo.generate_contract_tests!
         end
       end
 
-      context "rails option set to true in file" do
-        it "sets rails option to true" do
-          allow(Rambo).to receive(:yaml_options).and_return({ rails: true })
+      context "framework set to sinatra:modular" do 
+        it "sets framework to sinatra:modular" do 
+          allow(Rambo).to receive(:yaml_options).and_return({ framework: :"sinatra:modular" })
           expect(Rambo::DocumentGenerator)
             .to receive(:generate!)
-            .with("/Users/dscheider/rambo/doc/raml/#{valid_file}", { rails: true })
+            .with("/Users/dscheider/rambo/doc/raml/#{valid_file}", { framework: :"sinatra:modular" })
           Rambo.generate_contract_tests!
         end
       end
 
-      context "rails option not set in file" do
-        it "sets rails option to true" do
+      context "framework set to Grape" do 
+        it "sets framework to Grape" do 
+          allow(Rambo).to receive(:yaml_options).and_return({ framework: :grape })
+          expect(Rambo::DocumentGenerator)
+            .to receive(:generate!)
+            .with("/Users/dscheider/rambo/doc/raml/#{valid_file}", { framework: :grape })
+          Rambo.generate_contract_tests!
+        end
+      end
+
+      context "framework set to Rails" do
+        it "sets framework to Rails" do
+          allow(Rambo).to receive(:yaml_options).and_return({ framework: :rails })
+          expect(Rambo::DocumentGenerator)
+            .to receive(:generate!)
+            .with("/Users/dscheider/rambo/doc/raml/#{valid_file}", { framework: :rails })
+          Rambo.generate_contract_tests!
+        end
+      end
+
+      context "framework option not set in file" do
+        it "sets framework to Rails" do
           allow(Rambo).to receive(:yaml_options).and_return({})
           expect(Rambo::DocumentGenerator)
             .to receive(:generate!)
-            .with(File.expand_path("/Users/dscheider/rambo/doc/raml/#{valid_file}"), { rails: true })
+            .with(File.expand_path("/Users/dscheider/rambo/doc/raml/#{valid_file}"), { framework: :rails })
           Rambo.generate_contract_tests!
         end
       end


### PR DESCRIPTION
This PR changes Rambo to support Rails, Sinatra, and Grape only, using the `--framework` command line option or `framework`/`:framework` option for files configured using a `.rambo.yml` file or the Ruby API, respectively. 

Note that support for [Rory](https://github.com/screamingmuse/rory) will be added back in version 0.7, to prevent breakage in Mandolin.