### PR TITLE
Update development dependencies

### DIFF
--- a/rambo_ruby.gemspec
+++ b/rambo_ruby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency "cucumber", "~> 2.1"
-  s.add_development_dependency "json", "~> 1.7"
+  s.add_development_dependency "json", ">= 1.7"
   s.add_development_dependency "coveralls", "~> 0.7"
   s.add_development_dependency "aruba", "~> 0.13"
 


### PR DESCRIPTION
This PR modifies the version requirement for the JSON gem to `">= 1.7"` from `"~> 1.7"`.