### PR TITLE
Allow newer versions of Rake

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,7 +1,7 @@
 module Rambo
   MAJOR = '0'
   MINOR = '7'
-  PATCH = '0'
+  PATCH = '1'
 
   def self.version
     [Rambo::MAJOR, Rambo::MINOR, Rambo::PATCH].join('.')

--- a/rambo_ruby.gemspec
+++ b/rambo_ruby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "colorize", "~> 0.7"
   s.add_dependency "json_test_data", "~> 1.1", ">= 1.1.3"
   s.add_dependency "json-schema", "~> 2.6"
-  s.add_dependency "rake", "~> 11.0"
+  s.add_dependency "rake", ">= 11.0"
 
   if RUBY_VERSION < "2.2.2"
     s.add_dependency "activesupport", "~> 4.0"


### PR DESCRIPTION
This PR changes the required Rake version from `~> 11.0` to `>= 11.0` to account for the recent release of version 12.